### PR TITLE
Fix CI to run only native tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,4 @@ jobs:
         run: pip install --upgrade platformio
 
       - name: Test PlatformIO Project
-        run: pio test --without-uploading
+        run: pio test -e native


### PR DESCRIPTION
The CI was failing because it was trying to run tests for the `seeed_xiao_rp2040` environment, which requires a physical device. This change modifies the CI configuration to run only the native tests, which are designed to run in a simulated environment.

Fixes #60

---
*PR created automatically by Jules for task [15041330442477287056](https://jules.google.com/task/15041330442477287056) started by @chatelao*