### PR TITLE
Add Standard CVs and Native Tests

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -14,9 +14,9 @@ test_ignore = test_native
 [env:native]
 platform = native
 test_framework = unity
-lib_deps =
-  fabiobatsilva/ArduinoFake
 build_flags = -I test/mocks
+test_build_src = true
+build_src_filter = +<CvManager.cpp>
 test_ignore =
   test_protocol_handler
   test_simple

--- a/test/mocks/Arduino.h
+++ b/test/mocks/Arduino.h
@@ -3,7 +3,7 @@
 
 #include <cstdint>
 
-void analogWriteFreq(int freq) {}
-void analogWriteRange(int range) {}
+void analogWriteFreq(int freq);
+void analogWriteRange(int range);
 
 #endif // ARDUINO_MOCK_H

--- a/test/mocks/RP2040.h
+++ b/test/mocks/RP2040.h
@@ -1,0 +1,11 @@
+#ifndef RP2040_H
+#define RP2040_H
+
+class RP2040 {
+public:
+    void reboot();
+};
+
+extern RP2040 rp2040;
+
+#endif // RP2040_H

--- a/test/test_native/Arduino.cpp
+++ b/test/test_native/Arduino.cpp
@@ -1,0 +1,4 @@
+#include "Arduino.h"
+
+void analogWriteFreq(int freq) {}
+void analogWriteRange(int range) {}

--- a/test/test_native/EEPROM.cpp
+++ b/test/test_native/EEPROM.cpp
@@ -1,0 +1,3 @@
+#include "EEPROM.h"
+
+EEPROMClass EEPROM;

--- a/test/test_native/test_cv_manager.cpp
+++ b/test/test_native/test_cv_manager.cpp
@@ -1,0 +1,59 @@
+#include <unity.h>
+#include "CvManager.h"
+#include "RP2040.h"
+
+// Mock implementation for RP2040 reboot
+bool reboot_called = false;
+RP2040 rp2040;
+void RP2040::reboot() {
+    reboot_called = true;
+}
+
+void test_cv_manager_get_set() {
+  CvManager cvManager;
+  cvManager.setup();
+  cvManager.setCv(10, 42);
+  TEST_ASSERT_EQUAL(42, cvManager.getCv(10));
+}
+
+void test_cv_manager_defaults() {
+  CvManager cvManager;
+  cvManager.setup();
+  TEST_ASSERT_EQUAL(3, cvManager.getCv(CV_BASE_ADDRESS));
+  TEST_ASSERT_EQUAL(1, cvManager.getCv(CV_START_VOLTAGE));
+  TEST_ASSERT_EQUAL(5, cvManager.getCv(CV_ACCELERATION));
+  TEST_ASSERT_EQUAL(5, cvManager.getCv(CV_BRAKING_TIME));
+  TEST_ASSERT_EQUAL(0, cvManager.getCv(CV_MAXIMUM_SPEED));
+  TEST_ASSERT_EQUAL(10, cvManager.getCv(CV_VERSION));
+  TEST_ASSERT_EQUAL(13, cvManager.getCv(CV_MANUFACTURER_ID));
+  TEST_ASSERT_EQUAL(192, cvManager.getCv(CV_LONG_ADDRESS_HIGH));
+  TEST_ASSERT_EQUAL(100, cvManager.getCv(CV_LONG_ADDRESS_LOW));
+  TEST_ASSERT_EQUAL(6, cvManager.getCv(CV_CONFIGURATION));
+  TEST_ASSERT_EQUAL(1, cvManager.getCv(CV_FRONT_LIGHT_F0F));
+  TEST_ASSERT_EQUAL(2, cvManager.getCv(CV_REAR_LIGHT_F0R));
+  TEST_ASSERT_EQUAL(1, cvManager.getCv(CV_EXT_ID_HIGH));
+  TEST_ASSERT_EQUAL(10, cvManager.getCv(CV_EXT_ID_LOW));
+}
+
+void test_cv_manager_special() {
+  CvManager cvManager;
+  cvManager.setup();
+
+  // Test read-only CV
+  uint8_t version = cvManager.getCv(CV_VERSION);
+  cvManager.setCv(CV_VERSION, version + 1);
+  TEST_ASSERT_EQUAL(version, cvManager.getCv(CV_VERSION));
+
+  // Test reset CV
+  reboot_called = false;
+  cvManager.setCv(CV_MANUFACTURER_ID, 0);
+  TEST_ASSERT_TRUE(reboot_called);
+}
+
+void setUp(void) {
+  reboot_called = false;
+}
+
+void tearDown(void) {
+  // clean stuff up here
+}

--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -1,6 +1,11 @@
 #include <Arduino.h>
 #include <unity.h>
 
+// Forward declarations for test functions
+void test_cv_manager_get_set(void);
+void test_cv_manager_defaults(void);
+void test_cv_manager_special(void);
+
 void test_native_environment(void) {
     TEST_ASSERT_EQUAL(true, true);
 }
@@ -8,5 +13,8 @@ void test_native_environment(void) {
 int main(int argc, char **argv) {
     UNITY_BEGIN();
     RUN_TEST(test_native_environment);
+    RUN_TEST(test_cv_manager_get_set);
+    RUN_TEST(test_cv_manager_defaults);
+    RUN_TEST(test_cv_manager_special);
     return UNITY_END();
 }

--- a/xDuinoRails_MM/CvManager.cpp
+++ b/xDuinoRails_MM/CvManager.cpp
@@ -1,7 +1,7 @@
 #include "CvManager.h"
 #include <EEPROM.h>
+#include <RP2040.h>
 
-const int CV_ADDRESS = 1;
 const uint8_t EEPROM_MAGIC_BYTE = 0xAF;
 const int EEPROM_MAGIC_BYTE_ADDR = 0;
 
@@ -12,19 +12,37 @@ void CvManager::setup() {
   initCv();
 }
 
-uint8_t CvManager::getCv(int cv) {
-  return EEPROM.read(cv);
-}
+uint8_t CvManager::getCv(int cv) { return EEPROM.read(cv); }
 
 void CvManager::setCv(int cv, uint8_t value) {
+  if (cv == CV_VERSION) {
+    return;
+  }
   EEPROM.write(cv, value);
   EEPROM.commit();
+
+  if (cv == CV_MANUFACTURER_ID) {
+    rp2040.reboot();
+  }
 }
 
 void CvManager::initCv() {
   if (EEPROM.read(EEPROM_MAGIC_BYTE_ADDR) != EEPROM_MAGIC_BYTE) {
     EEPROM.write(EEPROM_MAGIC_BYTE_ADDR, EEPROM_MAGIC_BYTE);
-    setCv(CV_ADDRESS, 24);
+    setCv(CV_BASE_ADDRESS, 3);
+    setCv(CV_START_VOLTAGE, 1);
+    setCv(CV_ACCELERATION, 5);
+    setCv(CV_BRAKING_TIME, 5);
+    setCv(CV_MAXIMUM_SPEED, 0);
+    EEPROM.write(CV_VERSION, 10);
+    setCv(CV_MANUFACTURER_ID, 13);
+    setCv(CV_LONG_ADDRESS_HIGH, 192);
+    setCv(CV_LONG_ADDRESS_LOW, 100);
+    setCv(CV_CONFIGURATION, 6);
+    setCv(CV_FRONT_LIGHT_F0F, 1);
+    setCv(CV_REAR_LIGHT_F0R, 2);
+    setCv(CV_EXT_ID_HIGH, 1);
+    setCv(CV_EXT_ID_LOW, 10);
     EEPROM.commit();
   }
 }

--- a/xDuinoRails_MM/CvManager.h
+++ b/xDuinoRails_MM/CvManager.h
@@ -3,6 +3,22 @@
 
 #include <Arduino.h>
 
+// CV Adddresses
+constexpr int CV_BASE_ADDRESS = 1;
+constexpr int CV_START_VOLTAGE = 2;
+constexpr int CV_ACCELERATION = 3;
+constexpr int CV_BRAKING_TIME = 4;
+constexpr int CV_MAXIMUM_SPEED = 5;
+constexpr int CV_VERSION = 7;
+constexpr int CV_MANUFACTURER_ID = 8;
+constexpr int CV_LONG_ADDRESS_HIGH = 17;
+constexpr int CV_LONG_ADDRESS_LOW = 18;
+constexpr int CV_CONFIGURATION = 29;
+constexpr int CV_FRONT_LIGHT_F0F = 33;
+constexpr int CV_REAR_LIGHT_F0R = 34;
+constexpr int CV_EXT_ID_HIGH = 107;
+constexpr int CV_EXT_ID_LOW = 108;
+
 class CvManager {
  public:
   CvManager();


### PR DESCRIPTION
This change adds support for all standard CVs, including default values, special handling for read-only and reset CVs, and a full suite of native unit tests.

Fixes #66

---
*PR created automatically by Jules for task [16978847747940570482](https://jules.google.com/task/16978847747940570482) started by @chatelao*