### PR TITLE
Add Native Test for MM Signal Handling

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -15,8 +15,9 @@ test_ignore = test_native
 platform = native
 test_framework = unity
 build_flags = -I test/mocks
+lib_ignore = MaerklinMotorola
 test_build_src = true
-build_src_filter = +<CvManager.cpp> +<MotorControl.cpp> +<LightsControl.cpp>
+build_src_filter = +<CvManager.cpp> +<MotorControl.cpp> +<LightsControl.cpp> +<ProtocolHandler.cpp>
 test_ignore =
   test_protocol_handler
   test_simple

--- a/test/mocks/MaerklinMotorola.h
+++ b/test/mocks/MaerklinMotorola.h
@@ -1,20 +1,39 @@
 #ifndef MAERKLIN_MOTOROLA_H
 #define MAERKLIN_MOTOROLA_H
 
+#include <Arduino.h>
+
 // Mock implementation of MaerklinMotorola.h for native testing
 enum MM2DirectionState {
   MM2DirectionState_Forward,
-  MM2DirectionState_Backward
+  MM2DirectionState_Backward,
+  MM2DirectionState_Unavailable
+};
+
+struct MaerklinMotorolaData {
+  int               Address;
+  int               Speed;
+  bool              Function;
+  bool              ChangeDir;
+  bool              IsMM2;
+  MM2DirectionState MM2Direction;
+  int               MM2FunctionIndex;
+  bool              IsMM2FunctionOn;
+  bool              IsMagnet;
 };
 
 class MaerklinMotorola {
 public:
-  void              setup(int pin) {}
-  void              loop() {}
-  int               getAddress() { return 0; }
-  int               getSpeed() { return 0; }
-  MM2DirectionState getDirection() { return MM2DirectionState_Forward; }
-  bool              getFunctionState(int f) { return false; }
+  MaerklinMotorola(int pin){};
+  void                 PinChange(){};
+  void                 Parse(){};
+  MaerklinMotorolaData *GetData();
+  void SetData(int address, int speed, bool function, bool changeDir, bool isMM2,
+               MM2DirectionState mm2Direction, int mm2FunctionIndex,
+               bool isMM2FunctionOn);
+
+private:
+  MaerklinMotorolaData data;
 };
 
 #endif // MAERKLIN_MOTOROLA_H

--- a/test/test_native/MaerklinMotorola.cpp
+++ b/test/test_native/MaerklinMotorola.cpp
@@ -1,0 +1,28 @@
+#include "mocks/MaerklinMotorola.h"
+
+static MaerklinMotorolaData mockData;
+static bool                 dataAvailable = false;
+
+MaerklinMotorolaData *MaerklinMotorola::GetData() {
+  if (dataAvailable) {
+    dataAvailable = false;
+    return &mockData;
+  }
+  return nullptr;
+}
+
+void MaerklinMotorola::SetData(int address, int speed, bool function,
+                               bool changeDir, bool isMM2,
+                               MM2DirectionState mm2Direction,
+                               int mm2FunctionIndex, bool isMM2FunctionOn) {
+  mockData.Address         = address;
+  mockData.Speed           = speed;
+  mockData.Function        = function;
+  mockData.ChangeDir       = changeDir;
+  mockData.IsMM2           = isMM2;
+  mockData.MM2Direction    = mm2Direction;
+  mockData.MM2FunctionIndex = mm2FunctionIndex;
+  mockData.IsMM2FunctionOn = isMM2FunctionOn;
+  mockData.IsMagnet        = false;
+  dataAvailable            = true;
+}

--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -1,9 +1,12 @@
 #include "CvManager.h"
 #include "LightsControl.h"
 #include "MotorControl.h"
+#include "ProtocolHandler.h"
 #include "RP2040.h"
 #include "mocks/CvManager.h"
 #include <unity.h>
+
+void test_mm_signal_f0_f1_f2(void);
 
 // Mock implementation for RP2040 reboot
 bool   reboot_called = false;
@@ -66,6 +69,41 @@ void test_lights_control_default_behavior(void) {
   // TODO: Add assertions to check the default lighting behavior
 }
 
+void test_mm_signal_f0_f1_f2(void) {
+  ProtocolHandler protocol(0);
+  protocol.setAddress(1);
+
+  // Simulate an MM2 signal with F1 on
+  protocol.mm.SetData(1, 0, false, true, true, MM2DirectionState_Forward, 1, true);
+  protocol.loop();
+  TEST_ASSERT_TRUE(protocol.getFunctionState(1));
+
+  // Simulate an MM2 signal with F1 off
+  protocol.mm.SetData(1, 0, false, true, true, MM2DirectionState_Forward, 1, false);
+  protocol.loop();
+  TEST_ASSERT_FALSE(protocol.getFunctionState(1));
+
+  // Simulate an MM2 signal with F2 on
+  protocol.mm.SetData(1, 0, false, true, true, MM2DirectionState_Forward, 2, true);
+  protocol.loop();
+  TEST_ASSERT_TRUE(protocol.getFunctionState(2));
+
+  // Simulate an MM2 signal with F2 off
+  protocol.mm.SetData(1, 0, false, true, true, MM2DirectionState_Forward, 2, false);
+  protocol.loop();
+  TEST_ASSERT_FALSE(protocol.getFunctionState(2));
+
+  // Simulate an MM signal with F0 on
+  protocol.mm.SetData(1, 0, true, false, false, MM2DirectionState_Unavailable, 0, false);
+  protocol.loop();
+  TEST_ASSERT_TRUE(protocol.getFunctionState(0));
+
+  // Simulate an MM signal with F0 off
+  protocol.mm.SetData(1, 0, false, false, false, MM2DirectionState_Unavailable, 0, false);
+  protocol.loop();
+  TEST_ASSERT_FALSE(protocol.getFunctionState(0));
+}
+
 void setUp(void) { reboot_called = false; }
 
 void tearDown(void) {
@@ -79,5 +117,6 @@ int main(int argc, char **argv) {
   RUN_TEST(test_cv_manager_special);
   RUN_TEST(test_motor_control_default_parameters);
   RUN_TEST(test_lights_control_default_behavior);
+  RUN_TEST(test_mm_signal_f0_f1_f2);
   return UNITY_END();
 }

--- a/xDuinoRails_MM/ProtocolHandler.cpp
+++ b/xDuinoRails_MM/ProtocolHandler.cpp
@@ -1,8 +1,10 @@
 #include "ProtocolHandler.h"
 
+#ifndef PIO_UNIT_TESTING
 extern ProtocolHandler protocol;
 
 void isr_protocol() { protocol.mm.PinChange(); }
+#endif
 
 ProtocolHandler::ProtocolHandler(int dccMmSignalPin)
     : mm(dccMmSignalPin), mmTimeoutMs(MM_TIMEOUT_MS),
@@ -21,8 +23,10 @@ ProtocolHandler::ProtocolHandler(int dccMmSignalPin)
 }
 
 void ProtocolHandler::setup() {
+#ifndef PIO_UNIT_TESTING
   attachInterrupt(digitalPinToInterrupt(dccMmSignalPin_priv), isr_protocol,
                   CHANGE);
+#endif
   lastCommandTime = millis();
 }
 


### PR DESCRIPTION
This submission adds a native test case to verify the correct handling of Märklin Motorola (MM) signals for functions F0, F1, and F2. It includes a new test function, a mock for the `MaerklinMotorola` library, and necessary updates to the build configuration. The production code was refactored to ensure it compiles and links correctly in the native test environment. All tests pass, and the changes have been reviewed.

Fixes #89

---
*PR created automatically by Jules for task [10232863332749077396](https://jules.google.com/task/10232863332749077396) started by @chatelao*