### PR TITLE
Add XIAO ESP32-C6 Support

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -11,6 +11,16 @@ lib_deps =
 test_build_src = true
 test_ignore = test_native
 
+[env:seeed_xiao_esp32c6]
+platform = espressif32
+board = seeed_xiao_esp32c6
+framework = arduino
+lib_deps =
+  adafruit/Adafruit NeoPixel
+  laserlicht/MaerklinMotorola
+test_build_src = true
+test_ignore = test_native
+
 [env:native]
 platform = native
 test_framework = unity

--- a/xDuinoRails_MM/CvManager.cpp
+++ b/xDuinoRails_MM/CvManager.cpp
@@ -1,6 +1,8 @@
 #include "CvManager.h"
 #include <EEPROM.h>
+#if defined(ARDUINO_ARCH_RP2040) || defined(PIO_UNIT_TESTING)
 #include <RP2040.h>
+#endif
 
 const uint8_t EEPROM_MAGIC_BYTE      = 0xAF;
 const int     EEPROM_MAGIC_BYTE_ADDR = 0;
@@ -27,7 +29,11 @@ void CvManager::setCv(int cv, uint8_t value) {
   EEPROM.commit();
 
   if (cv == CV_MANUFACTURER_ID) {
+#if defined(ARDUINO_ARCH_RP2040) || defined(PIO_UNIT_TESTING)
     rp2040.reboot();
+#elif defined(ARDUINO_ARCH_ESP32)
+    ESP.restart();
+#endif
   }
 }
 

--- a/xDuinoRails_MM/DebugLeds.cpp
+++ b/xDuinoRails_MM/DebugLeds.cpp
@@ -11,18 +11,32 @@ DebugLeds::DebugLeds(int neoPin, int neoPwrPin, int numPixels, int redPin,
 }
 
 void DebugLeds::setup() {
-  pinMode(neoPwrPin_priv, OUTPUT);
-  digitalWrite(neoPwrPin_priv, HIGH);
-  delay(10);
-  pixels.begin();
-  pixels.setBrightness(40);
+  if (neoPwrPin_priv >= 0) {
+    pinMode(neoPwrPin_priv, OUTPUT);
+    digitalWrite(neoPwrPin_priv, HIGH);
+    delay(10);
+  }
 
-  pinMode(redPin_priv, OUTPUT);
-  digitalWrite(redPin_priv, HIGH);
-  pinMode(greenPin_priv, OUTPUT);
-  digitalWrite(greenPin_priv, HIGH);
-  pinMode(bluePin_priv, OUTPUT);
-  digitalWrite(bluePin_priv, HIGH);
+  // pixels always needs begin, but we check pin in constructor?
+  // Actually Adafruit_NeoPixel handles -1 pin by not doing anything usually,
+  // but let's be safe.
+  if (pixels.getPin() >= 0) {
+    pixels.begin();
+    pixels.setBrightness(40);
+  }
+
+  if (redPin_priv >= 0) {
+    pinMode(redPin_priv, OUTPUT);
+    digitalWrite(redPin_priv, HIGH);
+  }
+  if (greenPin_priv >= 0) {
+    pinMode(greenPin_priv, OUTPUT);
+    digitalWrite(greenPin_priv, HIGH);
+  }
+  if (bluePin_priv >= 0) {
+    pinMode(bluePin_priv, OUTPUT);
+    digitalWrite(bluePin_priv, HIGH);
+  }
 }
 
 void DebugLeds::update(int speedStep, bool f1, bool isMm2Locked,
@@ -33,8 +47,13 @@ void DebugLeds::update(int speedStep, bool f1, bool isMm2Locked,
     return;
   lastVisUpdate = now;
 
-  setIntLed(redPin_priv, isMm2Locked);
-  setIntLed(bluePin_priv, f1);
+  if (redPin_priv >= 0)
+    setIntLed(redPin_priv, isMm2Locked);
+  if (bluePin_priv >= 0)
+    setIntLed(bluePin_priv, f1);
+
+  if (pixels.getPin() < 0)
+    return;
 
   if (isTimeout) {
     if ((now / 250) % 2) {

--- a/xDuinoRails_MM/MotorControl.cpp
+++ b/xDuinoRails_MM/MotorControl.cpp
@@ -54,8 +54,13 @@ void MotorControl::setup() {
   pinMode(bemfA_priv, INPUT);
   pinMode(bemfB_priv, INPUT);
 
+#ifdef ARDUINO_ARCH_RP2040
   analogWriteFreq(PWM_FREQ);
   analogWriteRange(PWM_RANGE);
+#elif defined(ARDUINO_ARCH_ESP32)
+  analogWriteFrequency(PWM_FREQ);
+  analogWriteResolution(10);
+#endif
 
   writeMotorHardware(0, MM2DirectionState_Forward);
 }

--- a/xDuinoRails_MM/idf_component.yml
+++ b/xDuinoRails_MM/idf_component.yml
@@ -1,0 +1,2 @@
+dependencies:
+  idf: '>=5.1'

--- a/xDuinoRails_MM/xDuinoRails_MM.ino
+++ b/xDuinoRails_MM/xDuinoRails_MM.ino
@@ -11,9 +11,10 @@
 // ==========================================
 
 // ==========================================
-// PIN DEFINITIONEN (Seeed XIAO RP2040)
+// PIN DEFINITIONEN
 // ==========================================
 
+#ifdef ARDUINO_ARCH_RP2040
 const int DCC_MM_SIGNAL = D2;
 
 const int MOTOR_PIN_A = D7;
@@ -29,6 +30,37 @@ const int PIN_INT_GREEN = 16;
 const int PIN_INT_BLUE  = 25;
 const int NEO_PIN       = 12;
 const int NEO_PWR_PIN   = 11;
+#elif defined(ARDUINO_ARCH_ESP32)
+const int DCC_MM_SIGNAL = D2;
+
+const int MOTOR_PIN_A = D7;
+const int MOTOR_PIN_B = D8;
+const int BEMF_PIN_A  = A0;
+const int BEMF_PIN_B  = A1;
+
+const int LED_F0b = D9;
+const int LED_F0f = D10;
+
+const int PIN_INT_RED   = 15; // User LED on XIAO ESP32-C6
+const int PIN_INT_GREEN = -1;
+const int PIN_INT_BLUE  = -1;
+const int NEO_PIN       = -1;
+const int NEO_PWR_PIN   = -1;
+#else
+// Fallback or other boards
+const int DCC_MM_SIGNAL = 2;
+const int MOTOR_PIN_A   = 7;
+const int MOTOR_PIN_B   = 8;
+const int BEMF_PIN_A    = A0;
+const int BEMF_PIN_B    = A1;
+const int LED_F0b       = 9;
+const int LED_F0f       = 10;
+const int PIN_INT_RED   = -1;
+const int PIN_INT_GREEN = -1;
+const int PIN_INT_BLUE  = -1;
+const int NEO_PIN       = -1;
+const int NEO_PWR_PIN   = -1;
+#endif
 
 const int NUMPIXELS = 1;
 
@@ -57,7 +89,9 @@ void isr_protocol();
 // ==========================================
 #ifndef PIO_UNIT_TESTING
 void setup() {
-  analogReadResolution(12); // Wichtig für RP2040 (0-4095)
+#if defined(ARDUINO_ARCH_RP2040) || defined(ARDUINO_ARCH_ESP32)
+  analogReadResolution(12); // Wichtig für RP2040 & ESP32 (0-4095)
+#endif
   cvManager.setup();
   protocol.setAddress(cvManager.getCv(1));
   protocol.setup();


### PR DESCRIPTION
This change adds the Seeed Studio XIAO ESP32-C6 as a supported build target. It introduces architectural abstractions for rebooting and PWM configuration, adds board-specific pin definitions, and improves hardware safety in the LED debugging module. Build verification was performed for the existing RP2040 target and via native tests, though environment-specific PlatformIO limitations hindered a full successful compilation for the new C6 target in the current sandbox.

---
*PR created automatically by Jules for task [12931857440274787621](https://jules.google.com/task/12931857440274787621) started by @chatelao*