### PR TITLE
Add Arduino CLI support and fix related protocol handler bugs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,25 @@ jobs:
       - name: Test PlatformIO Project
         run: pio test -e native --without-uploading
 
+  arduino-cli-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Arduino CLI
+        uses: arduino/setup-arduino-cli@v2
+      - name: Install RP2040 Core
+        run: |
+          arduino-cli core update-index
+          arduino-cli core install rp2040:rp2040
+      - name: Install Libraries
+        run: |
+          arduino-cli lib install "Adafruit NeoPixel"
+          arduino-cli lib install "MaerklinMotorola"
+      - name: Compile
+        run: arduino-cli compile xDuinoRails_MM
+
   release:
-    needs: build
+    needs: [build, arduino-cli-build]
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     steps:

--- a/arduino-cli.yaml
+++ b/arduino-cli.yaml
@@ -1,0 +1,3 @@
+board_manager:
+  additional_urls:
+    - https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json

--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -171,33 +171,37 @@ void test_cv_programming_6021(void) {
   cvManager.setCv(CV_PROGRAMMING_LOCK, 7);
 
   // 4 direction changes to enter programming mode
-  advance_millis(10); // Ensure first change is not at ts=0
-  protocol.mm.SetData(1, 5, false, false, true, MM2DirectionState_Forward, 0, false);
-  protocol.loop();
-  programmer.loop();
-  advance_millis(100);
+  for (int i = 0; i < 4; i++) {
+    advance_millis(300);
+    unsigned long now = millis();
+    // Send packet with changeDir = true
+    protocol.mm.SetData(1, 0, false, true, false, MM2DirectionState_Unavailable, 0, false);
+    protocol.loop();
+    TEST_ASSERT_EQUAL(now, protocol.getLastChangeDirTs());
+    programmer.loop();
 
-  protocol.mm.SetData(1, 5, false, false, true, MM2DirectionState_Backward, 0, false);
-  protocol.loop();
-  programmer.loop();
-  advance_millis(100);
+    advance_millis(100);
+    // Send packet with changeDir = false to reset lastChangeDirInput
+    protocol.mm.SetData(1, 0, false, false, false, MM2DirectionState_Unavailable, 0, false);
+    protocol.loop();
+    programmer.loop();
+  }
 
-  protocol.mm.SetData(1, 5, false, false, true, MM2DirectionState_Forward, 0, false);
-  protocol.loop();
-  programmer.loop();
+  // Now in programming mode
+  // Set CV 10 (address)
   advance_millis(100);
-
-  protocol.mm.SetData(1, 5, false, false, true, MM2DirectionState_Backward, 0, false);
+  unsigned long now = millis();
+  protocol.mm.SetData(1, 10, false, false, false, MM2DirectionState_Unavailable, 0, false);
   protocol.loop();
+  TEST_ASSERT_EQUAL(now, protocol.getLastSpeedChangeTs());
   programmer.loop();
 
-  // Set CV 10 to 42
-  protocol.mm.SetData(1, 10, false, false, true, MM2DirectionState_Backward, 0, false);
-  protocol.loop();
-  programmer.loop();
+  // Set Value 42
   advance_millis(100);
-  protocol.mm.SetData(1, 42, false, false, true, MM2DirectionState_Backward, 0, false);
+  now = millis();
+  protocol.mm.SetData(1, 42, false, false, false, MM2DirectionState_Unavailable, 0, false);
   protocol.loop();
+  TEST_ASSERT_EQUAL(now, protocol.getLastSpeedChangeTs());
   programmer.loop();
 
   TEST_ASSERT_EQUAL(42, cvManager.getCv(10));

--- a/xDuinoRails_MM/ProtocolHandler.cpp
+++ b/xDuinoRails_MM/ProtocolHandler.cpp
@@ -40,11 +40,10 @@ void ProtocolHandler::loop() {
   if (Data && !Data->IsMagnet && Data->Address == mmAddress) {
     lastCommandTime = now;
 
-    bool mm2Locked = (now - lastMM2Seen < mm2LockTime);
-    if (Data->IsMM2)
-      lastMM2Seen = now;
+    bool mm2Locked = (lastMM2Seen > 0 && now - lastMM2Seen < mm2LockTime);
 
-    if (mm2Locked && Data->IsMM2) {
+    if (Data->IsMM2) {
+      lastMM2Seen = now;
       if (Data->MM2Direction != MM2DirectionState_Unavailable) {
         targetDirection = Data->MM2Direction;
       }

--- a/xDuinoRails_MM/sketch.yaml
+++ b/xDuinoRails_MM/sketch.yaml
@@ -1,0 +1,5 @@
+default_fqbn: rp2040:rp2040:seeed_xiao_rp2040
+default_platform: rp2040:rp2040
+libraries:
+  - Adafruit NeoPixel
+  - MaerklinMotorola


### PR DESCRIPTION
This change enables the project to be compiled using the Arduino CLI, providing an alternative to PlatformIO for users and ensuring compatibility through CI. 

Key changes:
1. **Arduino CLI Configuration**: Added `arduino-cli.yaml` in the root and `sketch.yaml` in the `xDuinoRails_MM` directory to define the board (Seeed Xiao RP2040) and required libraries (`Adafruit NeoPixel`, `MaerklinMotorola`).
2. **CI Integration**: Added a new `arduino-cli-build` job to the GitHub Actions workflow.
3. **Bug Fix in ProtocolHandler**: Resolved an issue where the MM2 protocol lock-in was incorrectly engaged at startup (since `lastMM2Seen` was 0), which blocked MM1 packets for the first 5 seconds.
4. **Test Improvements**: Fixed the `test_cv_programming_6021` native test by using proper MM1 direction change sequences and addressing the timing requirements of the protocol handler. Verified that all native tests now pass.

---
*PR created automatically by Jules for task [2541400594002057107](https://jules.google.com/task/2541400594002057107) started by @chatelao*