### PR TITLE
Add support for Seeed XIAO ESP32-C6 board

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -11,10 +11,20 @@ lib_deps =
 test_build_src = true
 test_ignore = test_native
 
+[env:seeed_xiao_esp32c6]
+platform = https://github.com/pioarduino/platform-espressif32.git
+board = seeed_xiao_esp32c6
+framework = arduino
+lib_deps =
+  adafruit/Adafruit NeoPixel
+  laserlicht/MaerklinMotorola
+test_build_src = true
+test_ignore = test_native
+
 [env:native]
 platform = native
 test_framework = unity
-build_flags = -I test/mocks
+build_flags = -I test/mocks -DARDUINO_ARCH_RP2040
 lib_ignore = MaerklinMotorola
 test_build_src = true
 build_src_filter = +<CvManager.cpp> +<MotorControl.cpp> +<LightsControl.cpp> +<ProtocolHandler.cpp> +<CvProgrammer.cpp>

--- a/test/mocks/Arduino.h
+++ b/test/mocks/Arduino.h
@@ -11,21 +11,21 @@ extern std::map<uint8_t, int> digital_write_values;
 #define HIGH 0x1
 #define LOW  0x0
 
-#define INPUT 0x0
-#define OUTPUT 0x1
+#define INPUT        0x0
+#define OUTPUT       0x1
 #define INPUT_PULLUP 0x2
 
 void pinMode(uint8_t pin, uint8_t mode);
 void digitalWrite(uint8_t pin, uint8_t val);
-int analogRead(uint8_t pin);
+int  analogRead(uint8_t pin);
 void analogWrite(uint8_t pin, int val);
 void analogWriteFreq(int freq);
 void analogWriteRange(int range);
 
 unsigned long millis();
-void advance_millis(unsigned long ms);
-void delayMicroseconds(unsigned int us);
-void reset_arduino_mock();
-long map(long, long, long, long, long);
+void          advance_millis(unsigned long ms);
+void          delayMicroseconds(unsigned int us);
+void          reset_arduino_mock();
+long          map(long, long, long, long, long);
 
 #endif // ARDUINO_H

--- a/test/mocks/CvManagerMock.h
+++ b/test/mocks/CvManagerMock.h
@@ -8,21 +8,21 @@ class CvManagerMock : public CvManager {
 public:
   CvManagerMock() {
     // Seed with default CVs
-    cvStore[CV_BASE_ADDRESS] = 3;
-    cvStore[CV_START_VOLTAGE] = 1;
-    cvStore[CV_ACCELERATION] = 5;
-    cvStore[CV_BRAKING_TIME] = 5;
-    cvStore[CV_MAXIMUM_SPEED] = 0;
-    cvStore[CV_VERSION] = 10;
-    cvStore[CV_MANUFACTURER_ID] = 13;
+    cvStore[CV_BASE_ADDRESS]      = 3;
+    cvStore[CV_START_VOLTAGE]     = 1;
+    cvStore[CV_ACCELERATION]      = 5;
+    cvStore[CV_BRAKING_TIME]      = 5;
+    cvStore[CV_MAXIMUM_SPEED]     = 0;
+    cvStore[CV_VERSION]           = 10;
+    cvStore[CV_MANUFACTURER_ID]   = 13;
     cvStore[CV_LONG_ADDRESS_HIGH] = 192;
-    cvStore[CV_LONG_ADDRESS_LOW] = 100;
-    cvStore[CV_CONFIGURATION] = 6;
-    cvStore[CV_FRONT_LIGHT_F0F] = 1;
-    cvStore[CV_REAR_LIGHT_F0R] = 2;
-    cvStore[CV_EXT_ID_HIGH] = 1;
-    cvStore[CV_EXT_ID_LOW] = 10;
-    cvStore[CV_MOTOR_TYPE] = 0;
+    cvStore[CV_LONG_ADDRESS_LOW]  = 100;
+    cvStore[CV_CONFIGURATION]     = 6;
+    cvStore[CV_FRONT_LIGHT_F0F]   = 1;
+    cvStore[CV_REAR_LIGHT_F0R]    = 2;
+    cvStore[CV_EXT_ID_HIGH]       = 1;
+    cvStore[CV_EXT_ID_LOW]        = 10;
+    cvStore[CV_MOTOR_TYPE]        = 0;
   }
 
   uint8_t getCv(int cv) override {
@@ -33,8 +33,8 @@ public:
   }
 
   void setCv(int cv, uint8_t value) override {
-    cvStore[cv] = value;
-    lastSetCv = cv;
+    cvStore[cv]  = value;
+    lastSetCv    = cv;
     lastSetValue = value;
   }
 
@@ -43,8 +43,8 @@ public:
   }
 
   std::map<int, uint8_t> cvStore;
-  int lastSetCv = -1;
-  uint8_t lastSetValue = 0;
+  int                    lastSetCv    = -1;
+  uint8_t                lastSetValue = 0;
 };
 
 #endif // CV_MANAGER_MOCK_H

--- a/test/mocks/EEPROM.h
+++ b/test/mocks/EEPROM.h
@@ -5,10 +5,10 @@
 
 class EEPROMClass {
 public:
-  void begin(int size);
-  void commit();
-  uint8_t read(int address);
-  void write(int address, uint8_t value);
+  void                    begin(int size);
+  void                    commit();
+  uint8_t                 read(int address);
+  void                    write(int address, uint8_t value);
   template <typename T> T get(int address, T &data) {
     // A simple mock implementation
     return data;

--- a/test/mocks/MaerklinMotorola.h
+++ b/test/mocks/MaerklinMotorola.h
@@ -25,12 +25,12 @@ struct MaerklinMotorolaData {
 class MaerklinMotorola {
 public:
   MaerklinMotorola(int pin);
-  void                 PinChange(){};
-  void                 Parse(){};
-  bool                 hasChanged();
+  void                  PinChange() {};
+  void                  Parse() {};
+  bool                  hasChanged();
   MaerklinMotorolaData *GetData();
-  void SetData(int address, int speed, bool function, bool changeDir, bool isMM2,
-               MM2DirectionState mm2Direction, int mm2FunctionIndex,
+  void SetData(int address, int speed, bool function, bool changeDir,
+               bool isMM2, MM2DirectionState mm2Direction, int mm2FunctionIndex,
                bool isMM2FunctionOn);
 
 private:

--- a/test/test_native/Arduino.cpp
+++ b/test/test_native/Arduino.cpp
@@ -9,9 +9,7 @@ void pinMode(uint8_t pin, uint8_t mode) {
   // Mock implementation
 }
 
-void digitalWrite(uint8_t pin, uint8_t val) {
-  digital_write_values[pin] = val;
-}
+void digitalWrite(uint8_t pin, uint8_t val) { digital_write_values[pin] = val; }
 
 int analogRead(uint8_t pin) {
   // Mock implementation

--- a/test/test_native/EEPROM.cpp
+++ b/test/test_native/EEPROM.cpp
@@ -5,9 +5,7 @@ static std::vector<uint8_t> eeprom_memory;
 
 EEPROMClass EEPROM;
 
-void EEPROMClass::begin(int size) {
-  eeprom_memory.assign(size, 0xFF);
-}
+void EEPROMClass::begin(int size) { eeprom_memory.assign(size, 0xFF); }
 
 void EEPROMClass::commit() {
   // Mock implementation

--- a/test/test_native/MaerklinMotorola.cpp
+++ b/test/test_native/MaerklinMotorola.cpp
@@ -16,14 +16,14 @@ void MaerklinMotorola::SetData(int address, int speed, bool function,
                                bool changeDir, bool isMM2,
                                MM2DirectionState mm2Direction,
                                int mm2FunctionIndex, bool isMM2FunctionOn) {
-  this->data.Address         = address;
-  this->data.Speed           = speed;
-  this->data.Function        = function;
-  this->data.ChangeDir       = changeDir;
-  this->data.IsMM2           = isMM2;
-  this->data.MM2Direction    = mm2Direction;
+  this->data.Address          = address;
+  this->data.Speed            = speed;
+  this->data.Function         = function;
+  this->data.ChangeDir        = changeDir;
+  this->data.IsMM2            = isMM2;
+  this->data.MM2Direction     = mm2Direction;
   this->data.MM2FunctionIndex = mm2FunctionIndex;
-  this->data.IsMM2FunctionOn = isMM2FunctionOn;
-  this->data.IsMagnet        = false;
-  this->dataAvailable        = true;
+  this->data.IsMM2FunctionOn  = isMM2FunctionOn;
+  this->data.IsMagnet         = false;
+  this->dataAvailable         = true;
 }

--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -1,10 +1,10 @@
 #include "CvManager.h"
+#include "CvManagerMock.h"
 #include "CvProgrammer.h"
 #include "LightsControl.h"
 #include "MotorControl.h"
 #include "ProtocolHandler.h"
 #include "RP2040.h"
-#include "CvManagerMock.h"
 #include <unity.h>
 
 void test_mm_signal_f0_f1_f2(void);
@@ -47,7 +47,8 @@ void test_cv_manager_defaults(void) {
   TEST_ASSERT_EQUAL(10, cvManager.getCv(CV_EXT_ID_LOW));
 }
 
-// Testet spezielle CV-Funktionen wie schreibgeschützte CVs und den Reset-Mechanismus.
+// Testet spezielle CV-Funktionen wie schreibgeschützte CVs und den
+// Reset-Mechanismus.
 void test_cv_manager_special(void) {
   CvManager cvManager;
   cvManager.setup();
@@ -74,7 +75,7 @@ void test_motor_speed_control(void) {
   cvManager.setCv(CV_START_VOLTAGE, 1);
   cvManager.setCv(CV_MOTOR_TYPE, 0);
   cvManager.setCv(CV_MAXIMUM_SPEED, 200);
-  MotorControl  motor(cvManager, 10, 11, 2, 3);
+  MotorControl motor(cvManager, 10, 11, 2, 3);
   motor.setup();
 
   // Test: Geschwindigkeit 0
@@ -94,8 +95,10 @@ void test_motor_speed_control(void) {
   motor.setSpeed(0, MM2DirectionState_Forward); // Erst anhalten
   motor.setSpeed(1, MM2DirectionState_Backward);
   advance_millis(101);
-  motor.setSpeed(1, MM2DirectionState_Backward); // Dieser Aufruf stoppt den Motor
-  motor.setSpeed(1, MM2DirectionState_Backward); // Dieser wendet die Leistung an
+  motor.setSpeed(1,
+                 MM2DirectionState_Backward); // Dieser Aufruf stoppt den Motor
+  motor.setSpeed(1,
+                 MM2DirectionState_Backward); // Dieser wendet die Leistung an
   TEST_ASSERT_EQUAL(LOW, digital_write_values[10]);
   TEST_ASSERT_EQUAL(40, analog_write_values[11]);
 
@@ -131,32 +134,38 @@ void test_mm_signal_f0_f1_f2(void) {
   protocol.setAddress(1);
 
   // Simuliere ein MM2-Signal mit F1 an
-  protocol.mm.SetData(1, 0, false, true, true, MM2DirectionState_Forward, 1, true);
+  protocol.mm.SetData(1, 0, false, true, true, MM2DirectionState_Forward, 1,
+                      true);
   protocol.loop();
   TEST_ASSERT_TRUE(protocol.getFunctionState(1));
 
   // Simuliere ein MM2-Signal mit F1 aus
-  protocol.mm.SetData(1, 0, false, true, true, MM2DirectionState_Forward, 1, false);
+  protocol.mm.SetData(1, 0, false, true, true, MM2DirectionState_Forward, 1,
+                      false);
   protocol.loop();
   TEST_ASSERT_FALSE(protocol.getFunctionState(1));
 
   // Simuliere ein MM2-Signal mit F2 an
-  protocol.mm.SetData(1, 0, false, true, true, MM2DirectionState_Forward, 2, true);
+  protocol.mm.SetData(1, 0, false, true, true, MM2DirectionState_Forward, 2,
+                      true);
   protocol.loop();
   TEST_ASSERT_TRUE(protocol.getFunctionState(2));
 
   // Simuliere ein MM2-Signal mit F2 aus
-  protocol.mm.SetData(1, 0, false, true, true, MM2DirectionState_Forward, 2, false);
+  protocol.mm.SetData(1, 0, false, true, true, MM2DirectionState_Forward, 2,
+                      false);
   protocol.loop();
   TEST_ASSERT_FALSE(protocol.getFunctionState(2));
 
   // Simuliere ein MM-Signal mit F0 an
-  protocol.mm.SetData(1, 0, true, false, false, MM2DirectionState_Unavailable, 0, false);
+  protocol.mm.SetData(1, 0, true, false, false, MM2DirectionState_Unavailable,
+                      0, false);
   protocol.loop();
   TEST_ASSERT_TRUE(protocol.getFunctionState(0));
 
   // Simuliere ein MM-Signal mit F0 aus
-  protocol.mm.SetData(1, 0, false, false, false, MM2DirectionState_Unavailable, 0, false);
+  protocol.mm.SetData(1, 0, false, false, false, MM2DirectionState_Unavailable,
+                      0, false);
   protocol.loop();
   TEST_ASSERT_FALSE(protocol.getFunctionState(0));
 }
@@ -165,7 +174,7 @@ void test_cv_programming_6021(void) {
   CvManagerMock   cvManager;
   ProtocolHandler protocol(0);
   protocol.setAddress(1);
-  CvProgrammer    programmer(&cvManager, &protocol);
+  CvProgrammer programmer(&cvManager, &protocol);
 
   // Set CV 15 to 7 to enable programming
   cvManager.setCv(CV_PROGRAMMING_LOCK, 7);
@@ -175,14 +184,16 @@ void test_cv_programming_6021(void) {
     advance_millis(300);
     unsigned long now = millis();
     // Send packet with changeDir = true
-    protocol.mm.SetData(1, 0, false, true, false, MM2DirectionState_Unavailable, 0, false);
+    protocol.mm.SetData(1, 0, false, true, false, MM2DirectionState_Unavailable,
+                        0, false);
     protocol.loop();
     TEST_ASSERT_EQUAL(now, protocol.getLastChangeDirTs());
     programmer.loop();
 
     advance_millis(100);
     // Send packet with changeDir = false to reset lastChangeDirInput
-    protocol.mm.SetData(1, 0, false, false, false, MM2DirectionState_Unavailable, 0, false);
+    protocol.mm.SetData(1, 0, false, false, false,
+                        MM2DirectionState_Unavailable, 0, false);
     protocol.loop();
     programmer.loop();
   }
@@ -191,7 +202,8 @@ void test_cv_programming_6021(void) {
   // Set CV 10 (address)
   advance_millis(100);
   unsigned long now = millis();
-  protocol.mm.SetData(1, 10, false, false, false, MM2DirectionState_Unavailable, 0, false);
+  protocol.mm.SetData(1, 10, false, false, false, MM2DirectionState_Unavailable,
+                      0, false);
   protocol.loop();
   TEST_ASSERT_EQUAL(now, protocol.getLastSpeedChangeTs());
   programmer.loop();
@@ -199,7 +211,8 @@ void test_cv_programming_6021(void) {
   // Set Value 42
   advance_millis(100);
   now = millis();
-  protocol.mm.SetData(1, 42, false, false, false, MM2DirectionState_Unavailable, 0, false);
+  protocol.mm.SetData(1, 42, false, false, false, MM2DirectionState_Unavailable,
+                      0, false);
   protocol.loop();
   TEST_ASSERT_EQUAL(now, protocol.getLastSpeedChangeTs());
   programmer.loop();

--- a/test/test_simple/test_main.cpp
+++ b/test/test_simple/test_main.cpp
@@ -1,7 +1,8 @@
 #include <Arduino.h>
 #include <unity.h>
 
-// Testet eine einfache, grundlegende Behauptung, um die Funktionsfähigkeit des Test-Frameworks zu überprüfen.
+// Testet eine einfache, grundlegende Behauptung, um die Funktionsfähigkeit des
+// Test-Frameworks zu überprüfen.
 void test_simple_assertion(void) { TEST_ASSERT_EQUAL(1, 1); }
 
 void setup() {

--- a/xDuinoRails_MM/CvManager.cpp
+++ b/xDuinoRails_MM/CvManager.cpp
@@ -1,6 +1,8 @@
 #include "CvManager.h"
 #include <EEPROM.h>
+#ifdef ARDUINO_ARCH_RP2040
 #include <RP2040.h>
+#endif
 
 const uint8_t EEPROM_MAGIC_BYTE      = 0xAF;
 const int     EEPROM_MAGIC_BYTE_ADDR = 0;
@@ -27,7 +29,11 @@ void CvManager::setCv(int cv, uint8_t value) {
   EEPROM.commit();
 
   if (cv == CV_MANUFACTURER_ID) {
+#ifdef ARDUINO_ARCH_RP2040
     rp2040.reboot();
+#elif defined(ARDUINO_ARCH_ESP32)
+    ESP.restart();
+#endif
   }
 }
 

--- a/xDuinoRails_MM/DebugLeds.cpp
+++ b/xDuinoRails_MM/DebugLeds.cpp
@@ -3,6 +3,7 @@
 DebugLeds::DebugLeds(int neoPin, int neoPwrPin, int numPixels, int redPin,
                      int greenPin, int bluePin)
     : pixels(numPixels, neoPin, NEO_GRB + NEO_KHZ800) {
+  neoPin_priv    = neoPin;
   neoPwrPin_priv = neoPwrPin;
   redPin_priv    = redPin;
   greenPin_priv  = greenPin;
@@ -11,18 +12,29 @@ DebugLeds::DebugLeds(int neoPin, int neoPwrPin, int numPixels, int redPin,
 }
 
 void DebugLeds::setup() {
-  pinMode(neoPwrPin_priv, OUTPUT);
-  digitalWrite(neoPwrPin_priv, HIGH);
-  delay(10);
-  pixels.begin();
-  pixels.setBrightness(40);
+  if (neoPwrPin_priv != -1) {
+    pinMode(neoPwrPin_priv, OUTPUT);
+    digitalWrite(neoPwrPin_priv, HIGH);
+    delay(10);
+  }
 
-  pinMode(redPin_priv, OUTPUT);
-  digitalWrite(redPin_priv, HIGH);
-  pinMode(greenPin_priv, OUTPUT);
-  digitalWrite(greenPin_priv, HIGH);
-  pinMode(bluePin_priv, OUTPUT);
-  digitalWrite(bluePin_priv, HIGH);
+  if (neoPin_priv != -1) {
+    pixels.begin();
+    pixels.setBrightness(40);
+  }
+
+  if (redPin_priv != -1) {
+    pinMode(redPin_priv, OUTPUT);
+    digitalWrite(redPin_priv, HIGH);
+  }
+  if (greenPin_priv != -1) {
+    pinMode(greenPin_priv, OUTPUT);
+    digitalWrite(greenPin_priv, HIGH);
+  }
+  if (bluePin_priv != -1) {
+    pinMode(bluePin_priv, OUTPUT);
+    digitalWrite(bluePin_priv, HIGH);
+  }
 }
 
 void DebugLeds::update(int speedStep, bool f1, bool isMm2Locked,
@@ -33,29 +45,34 @@ void DebugLeds::update(int speedStep, bool f1, bool isMm2Locked,
     return;
   lastVisUpdate = now;
 
-  setIntLed(redPin_priv, isMm2Locked);
-  setIntLed(bluePin_priv, f1);
+  if (redPin_priv != -1)
+    setIntLed(redPin_priv, isMm2Locked);
+  if (bluePin_priv != -1)
+    setIntLed(bluePin_priv, f1);
 
-  if (isTimeout) {
-    if ((now / 250) % 2) {
-      pixels.setPixelColor(0, pixels.Color(255, 0, 0));
+  if (neoPin_priv != -1) {
+    if (isTimeout) {
+      if ((now / 250) % 2) {
+        pixels.setPixelColor(0, pixels.Color(255, 0, 0));
+      } else {
+        pixels.setPixelColor(0, 0);
+      }
+    } else if (isKickstarting) {
+      pixels.setPixelColor(0, pixels.Color(255, 255, 255)); // White on Kick
+    } else if (speedStep == 0) {
+      int val    = (now / 20) % 255;
+      int breath = (val > 127) ? 255 - val : val;
+      pixels.setPixelColor(0, pixels.Color(0, 0, breath * 2));
     } else {
-      pixels.setPixelColor(0, 0);
+      int r = map(speedStep, 0, 14, 0, 255);
+      int g = map(speedStep, 0, 14, 255, 0);
+      pixels.setPixelColor(0, pixels.Color(r, g, 0));
     }
-  } else if (isKickstarting) {
-    pixels.setPixelColor(0, pixels.Color(255, 255, 255)); // White on Kick
-  } else if (speedStep == 0) {
-    int val    = (now / 20) % 255;
-    int breath = (val > 127) ? 255 - val : val;
-    pixels.setPixelColor(0, pixels.Color(0, 0, breath * 2));
-  } else {
-    int r = map(speedStep, 0, 14, 0, 255);
-    int g = map(speedStep, 0, 14, 255, 0);
-    pixels.setPixelColor(0, pixels.Color(r, g, 0));
+    pixels.show();
   }
-  pixels.show();
 }
 
 void DebugLeds::setIntLed(int pin, bool on) {
-  digitalWrite(pin, on ? LOW : HIGH);
+  if (pin != -1)
+    digitalWrite(pin, on ? LOW : HIGH);
 }

--- a/xDuinoRails_MM/DebugLeds.h
+++ b/xDuinoRails_MM/DebugLeds.h
@@ -17,6 +17,7 @@ private:
   void              setIntLed(int pin, bool on);
   Adafruit_NeoPixel pixels;
   unsigned long     lastVisUpdate;
+  int               neoPin_priv;
   int               neoPwrPin_priv;
   int               redPin_priv;
   int               greenPin_priv;

--- a/xDuinoRails_MM/MotorControl.cpp
+++ b/xDuinoRails_MM/MotorControl.cpp
@@ -54,8 +54,15 @@ void MotorControl::setup() {
   pinMode(bemfA_priv, INPUT);
   pinMode(bemfB_priv, INPUT);
 
+#ifdef ARDUINO_ARCH_RP2040
   analogWriteFreq(PWM_FREQ);
   analogWriteRange(PWM_RANGE);
+#elif defined(ARDUINO_ARCH_ESP32)
+  analogWriteFrequency(pinA_priv, PWM_FREQ);
+  analogWriteFrequency(pinB_priv, PWM_FREQ);
+  analogWriteResolution(pinA_priv, 10); // 10 bits = 1023
+  analogWriteResolution(pinB_priv, 10); // 10 bits = 1023
+#endif
 
   writeMotorHardware(0, MM2DirectionState_Forward);
 }

--- a/xDuinoRails_MM/xDuinoRails_MM.ino
+++ b/xDuinoRails_MM/xDuinoRails_MM.ino
@@ -11,7 +11,7 @@
 // ==========================================
 
 // ==========================================
-// PIN DEFINITIONEN (Seeed XIAO RP2040)
+// PIN DEFINITIONEN
 // ==========================================
 
 const int DCC_MM_SIGNAL = D2;
@@ -24,11 +24,19 @@ const int BEMF_PIN_B  = A1;
 const int LED_F0b = D9;
 const int LED_F0f = D10;
 
+#ifdef ARDUINO_ARCH_RP2040
 const int PIN_INT_RED   = 17;
 const int PIN_INT_GREEN = 16;
 const int PIN_INT_BLUE  = 25;
 const int NEO_PIN       = 12;
 const int NEO_PWR_PIN   = 11;
+#elif defined(ARDUINO_ARCH_ESP32)
+const int PIN_INT_RED   = -1;
+const int PIN_INT_GREEN = -1;
+const int PIN_INT_BLUE  = 15; // LED_BUILTIN / D4
+const int NEO_PIN       = -1;
+const int NEO_PWR_PIN   = -1;
+#endif
 
 const int NUMPIXELS = 1;
 
@@ -40,7 +48,7 @@ CvManager cvManager;
 ProtocolHandler protocol(DCC_MM_SIGNAL);
 MotorControl motor(cvManager, MOTOR_PIN_A, MOTOR_PIN_B, BEMF_PIN_A, BEMF_PIN_B);
 LightsControl lights(cvManager, LED_F0f, LED_F0b);
-CvProgrammer cvProgrammer(&cvManager, &protocol);
+CvProgrammer  cvProgrammer(&cvManager, &protocol);
 
 DebugLeds debugLeds(NEO_PIN, NEO_PWR_PIN, NUMPIXELS, PIN_INT_RED, PIN_INT_GREEN,
                     PIN_INT_BLUE);
@@ -57,7 +65,7 @@ void isr_protocol();
 // ==========================================
 #ifndef PIO_UNIT_TESTING
 void setup() {
-  analogReadResolution(12); // Wichtig für RP2040 (0-4095)
+  analogReadResolution(12);
   cvManager.setup();
   protocol.setAddress(cvManager.getCv(1));
   protocol.setup();


### PR DESCRIPTION
This change adds support for the Seeed XIAO ESP32-C6 board. It includes the necessary PlatformIO configuration and source code modifications to handle hardware differences between the RP2040 and ESP32 architectures, specifically regarding PWM initialization, system reboot, and available on-board LEDs. The changes have been verified by successful compilation for both boards and passing native tests.

Fixes #113

---
*PR created automatically by Jules for task [6329947053155995597](https://jules.google.com/task/6329947053155995597) started by @chatelao*