### PR TITLE
Center values in "Default/Fix" column of CV_SUPPORT.md

### DIFF
--- a/documentation/CV_SUPPORT.md
+++ b/documentation/CV_SUPPORT.md
@@ -5,7 +5,7 @@ This document specifies the minimal supported Configuration Variables (CVs) for 
 ## CV Table
 
 | Emoji | CV | Name | Type | Default/Fix | Description |
-|---|---|---|---|---|---|
+|---|---|---|---|:---:|---|
 | 🏷️ | 1 | Base Address | Mandatory | 3 | The short address (1–127). |
 | ⚡ | 2 | Start Voltage | Standard | 1 - 5 | Minimum PWM for the motor to start at speed step 1. |
 | 📈 | 3 | Acceleration | Standard | 5 | "Chart Up": Time factor for smooth acceleration to maximum speed. |


### PR DESCRIPTION
The alignment of the "Default/Fix" column in `documentation/CV_SUPPORT.md` was changed to center-aligned by updating the table's header separator row.

Fixes #117

---
*PR created automatically by Jules for task [15092171292194773958](https://jules.google.com/task/15092171292194773958) started by @chatelao*