### PR TITLE
Add Seeed Studio XIAO RP2040 pinout ASCII art to source

### DIFF
--- a/xDuinoRails_MM/xDuinoRails_MM.ino
+++ b/xDuinoRails_MM/xDuinoRails_MM.ino
@@ -1,3 +1,17 @@
+/*
+ * Seeed Studio XIAO RP2040 Pinout for xDuinoRails_MM:
+ *
+ *                             +---USB---+
+ *               (BEMF A)  D0  | [ ] [ ] |  5V
+ *               (BEMF B)  D1  | [ ] [ ] |  GND
+ *            (DCC Input)  D2  | [ ] [ ] |  3V3
+ *                         D3  | [ ] [ ] |  D10 (Front Light)
+ *                         D4  | [ ] [ ] |  D9  (Rear Light)
+ *                         D5  | [ ] [ ] |  D8  (Motor B)
+ *                         D6  | [ ] [ ] |  D7  (Motor A)
+ *                             +---------+
+ */
+
 #include "CvManager.h"
 #include "CvProgrammer.h"
 #include "DebugLeds.h"


### PR DESCRIPTION
This PR adds a physical pinout diagram of the Seeed Studio XIAO RP2040 as ASCII art to the main entry point of the firmware (`xDuinoRails_MM.ino`). 

The diagram includes:
- Physical pin arrangement relative to the USB connector.
- Project-specific function mappings for each pin (e.g., DCC Input, Motor A/B, BEMF A/B, Lights).

The change is purely cosmetic (documentation within code) and has been verified to:
1. Compile successfully for the `seeed_xiao_rp2040` target.
2. Pass all native unit tests.
3. Align with the hardware specifications from the official Seeed Studio documentation.

Fixes #121

---
*PR created automatically by Jules for task [4676109536535058771](https://jules.google.com/task/4676109536535058771) started by @chatelao*