### PR TITLE
NeoPixel Direction and Speed Color Gradients

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -26,7 +26,8 @@ The Seeed Xiao RP2040's built-in LEDs and NeoPixel provide visual feedback on th
 
 ### NeoPixel LED
 - **Pulsing Blue:** Decoder is idle (Speed 0) and receiving signal.
-- **Color Gradient (Green to Red):** Indicates the current speed. Green is slow, Red is fast.
+- **Color Gradient (Forward):** Bright Green (slow) to White (fast).
+- **Color Gradient (Backward):** Bright Orange (slow) to Black/Off (fast).
 - **Flashing Red:** Timeout - No valid signal detected for more than 1 second.
 - **Solid White:** Motor kickstart is active.
 

--- a/xDuinoRails_MM/DebugLeds.cpp
+++ b/xDuinoRails_MM/DebugLeds.cpp
@@ -37,8 +37,8 @@ void DebugLeds::setup() {
   }
 }
 
-void DebugLeds::update(int speedStep, bool f1, bool isMm2Locked,
-                       bool isKickstarting, bool isTimeout) {
+void DebugLeds::update(int speedStep, MM2DirectionState direction, bool f1,
+                       bool isMm2Locked, bool isKickstarting, bool isTimeout) {
   unsigned long now = millis();
 
   if (now - lastVisUpdate < 50)
@@ -63,9 +63,13 @@ void DebugLeds::update(int speedStep, bool f1, bool isMm2Locked,
       int val    = (now / 20) % 255;
       int breath = (val > 127) ? 255 - val : val;
       pixels.setPixelColor(0, pixels.Color(0, 0, breath * 2));
+    } else if (direction == MM2DirectionState_Forward) {
+      int rb = map(speedStep, 1, 14, 0, 255);
+      pixels.setPixelColor(0, pixels.Color(rb, 255, rb));
     } else {
-      int r = map(speedStep, 0, 14, 0, 255);
-      int g = map(speedStep, 0, 14, 255, 0);
+      // Backward or Unavailable
+      int r = map(speedStep, 1, 14, 255, 0);
+      int g = map(speedStep, 1, 14, 128, 0);
       pixels.setPixelColor(0, pixels.Color(r, g, 0));
     }
     pixels.show();

--- a/xDuinoRails_MM/DebugLeds.h
+++ b/xDuinoRails_MM/DebugLeds.h
@@ -10,8 +10,8 @@ public:
   DebugLeds(int neoPin, int neoPwrPin, int numPixels, int redPin, int greenPin,
             int bluePin);
   void setup();
-  void update(int speedStep, bool f1, bool isMm2Locked, bool isKickstarting,
-              bool isTimeout);
+  void update(int speedStep, MM2DirectionState direction, bool f1,
+              bool isMm2Locked, bool isKickstarting, bool isTimeout);
 
 private:
   void              setIntLed(int pin, bool on);

--- a/xDuinoRails_MM/xDuinoRails_MM.ino
+++ b/xDuinoRails_MM/xDuinoRails_MM.ino
@@ -90,8 +90,8 @@ void loop() {
   }
 
   lights.update(motor.getCurrentDirection(), protocol.getFunctionState(0));
-  debugLeds.update(protocol.getTargetSpeed(), protocol.getFunctionState(1),
-                   protocol.isMm2Locked(), motor.isKickstarting(),
-                   protocol.isTimeout());
+  debugLeds.update(protocol.getTargetSpeed(), motor.getCurrentDirection(),
+                   protocol.getFunctionState(1), protocol.isMm2Locked(),
+                   motor.isKickstarting(), protocol.isTimeout());
 }
 #endif


### PR DESCRIPTION
This change implements direction-specific color gradients for the NeoPixel status LED.
Forward travel is indicated by a gradient from bright green to white.
Backward travel is indicated by a gradient from bright orange to black (off).
Idle state remains pulsing blue.
The implementation involves updating the `DebugLeds` class to accept `MM2DirectionState` and modifying the `update` logic to map speed steps to the new color schemes.
Documentation has been updated to reflect these changes.

Fixes #124

---
*PR created automatically by Jules for task [17583043136389076765](https://jules.google.com/task/17583043136389076765) started by @chatelao*