### PR TITLE
Update XIAO pinout to Thor mapping

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -8,21 +8,25 @@ The following pins are used for the decoder functions on the Seeed Xiao RP2040:
 
 | Function | Pin | Description |
 |---|---|---|
-| **DCC/MM Input** | D2 | Connect to the track signal via a suitable optocoupler/schmitt-trigger circuit. |
+| **DCC/MM/SX Input**| D5 | Connect to the track signal via optocoupler. |
+| **DCC-ACK** | D4 | Output for DCC acknowledgment. |
+| **RailCom** | D6 | Output for RailCom signal. |
 | **Motor A** | D7 | Motor output A. |
 | **Motor B** | D8 | Motor output B. |
 | **BEMF A** | A0 | Back-EMF sensing input A. |
 | **BEMF B** | A1 | Back-EMF sensing input B. |
-| **Front Light** | D10 | Forward direction light output (F0f). |
-| **Rear Light** | D9 | Backward direction light output (F0b). |
+| **Motor Shut** | A2 (D2) | Shutdown signal for motor driver. |
+| **Front Light** | D9 | Forward direction light output (F0f). |
+| **Rear Light** | D10 | Backward direction light output (F0b). |
+| **Functions Shut**| A3 (D3) | Shutdown signal for functions. |
 
 ## Status Indicators
 
 The Seeed Xiao RP2040's built-in LEDs and NeoPixel provide visual feedback on the decoder's state:
 
 ### Internal LEDs (RP2040)
-- **Red LED:** Lights up when the decoder has locked onto an MM2 signal.
-- **Blue LED:** Lights up when Function F1 is active.
+- **Red LED (D15):** Lights up when the decoder has locked onto an MM2 signal.
+- **Green LED (D16):** Lights up when Function F1 is active.
 
 ### NeoPixel LED
 - **Pulsing Blue:** Decoder is idle (Speed 0) and receiving signal.

--- a/xDuinoRails_MM/xDuinoRails_MM.ino
+++ b/xDuinoRails_MM/xDuinoRails_MM.ino
@@ -1,14 +1,14 @@
 /*
- * Seeed Studio XIAO RP2040 Pinout for xDuinoRails_MM:
+ * Seeed Studio XIAO RP2040 Pinout (Thor Mapping):
  *
  *                             +---USB---+
  *               (BEMF A)  D0  | [ ] [ ] |  5V
  *               (BEMF B)  D1  | [ ] [ ] |  GND
- *            (DCC Input)  D2  | [ ] [ ] |  3V3
- *                         D3  | [ ] [ ] |  D10 (Front Light)
- *                         D4  | [ ] [ ] |  D9  (Rear Light)
- *                         D5  | [ ] [ ] |  D8  (Motor B)
- *                         D6  | [ ] [ ] |  D7  (Motor A)
+ *          (Motor Shut)   D2  | [ ] [ ] |  3V3
+ *          (Func Shut)    D3  | [ ] [ ] |  D10 (Rear Light)
+ *          (DCC-ACK)      D4  | [ ] [ ] |  D9  (Front Light)
+ *          (DCC Input)    D5  | [ ] [ ] |  D8  (Motor B)
+ *          (RailCom)      D6  | [ ] [ ] |  D7  (Motor A)
  *                             +---------+
  */
 
@@ -28,20 +28,24 @@
 // PIN DEFINITIONEN
 // ==========================================
 
-const int DCC_MM_SIGNAL = D2;
+const int DCC_MM_SIGNAL = D5;
+const int DCC_ACK_PIN   = D4;
+const int RAILCOM_PIN   = D6;
 
-const int MOTOR_PIN_A = D7;
-const int MOTOR_PIN_B = D8;
-const int BEMF_PIN_A  = A0;
-const int BEMF_PIN_B  = A1;
+const int MOTOR_PIN_A    = D7;
+const int MOTOR_PIN_B    = D8;
+const int BEMF_PIN_A     = A0;
+const int BEMF_PIN_B     = A1;
+const int MOTOR_SHUT_PIN = A2; // D2
 
-const int LED_F0b = D9;
-const int LED_F0f = D10;
+const int LED_F0b        = D10;
+const int LED_F0f        = D9;
+const int FUNC_SHUT_PIN  = A3; // D3
 
 #ifdef ARDUINO_ARCH_RP2040
-const int PIN_INT_RED   = 17;
-const int PIN_INT_GREEN = 16;
-const int PIN_INT_BLUE  = 25;
+const int PIN_INT_RED   = 15;
+const int PIN_INT_GREEN = -1;
+const int PIN_INT_BLUE  = 16;
 const int NEO_PIN       = 12;
 const int NEO_PWR_PIN   = 11;
 #elif defined(ARDUINO_ARCH_ESP32)


### PR DESCRIPTION
This change updates the pin mapping of the Seeed Studio XIAO RP2040 to match the "xDuinoRails-Thor" hardware layout. It includes updates to the firmware source code (pin constants and internal LED mapping) and the user manual to reflect the new assignments. All changes were verified with local builds and native tests.

Fixes #129

---
*PR created automatically by Jules for task [474373902100959530](https://jules.google.com/task/474373902100959530) started by @chatelao*