### PR TITLE
Add CV reset logic for CV 8

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,3 +42,8 @@ AlignTrailingComments: true
 
 - **Dependency Injection:** For hardware configurations like pin numbers, use dependency injection by passing them into class constructors from a central configuration point (e.g., the main .ino file) rather than using global definitions via header files. This decouples classes from specific hardware setups.
 - **READMEs:** Add a basic `README.md` file to any new subdirectories to explain the purpose of the code within that directory.
+
+## CV Reset Logic
+- Writing the value 0 or 8 to CV 8 (Manufacturer ID) triggers a factory reset, restoring all CVs to their default values.
+- A reboot is automatically triggered after a CV reset or whenever CV 8 is written to.
+- Every new feature or logic change, like this reset mechanism, must be accompanied by native test cases in `test/test_native/` to ensure correctness and prevent regressions. These tests are executed automatically in the CI/CD pipeline.

--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -60,11 +60,28 @@ void test_cv_manager_special(void) {
   // Der Wert sollte unverändert sein
   TEST_ASSERT_EQUAL(version, cvManager.getCv(CV_VERSION));
 
-  // Teste den Reset-Mechanismus durch Schreiben auf CV_MANUFACTURER_ID
+  // Teste den Reset-Mechanismus durch Schreiben von 8 auf CV_MANUFACTURER_ID
+  // Zuerst eine CV ändern, um zu prüfen, ob sie zurückgesetzt wird
+  cvManager.setCv(CV_BASE_ADDRESS, 42);
+  TEST_ASSERT_EQUAL(42, cvManager.getCv(CV_BASE_ADDRESS));
+
+  reboot_called = false;
+  cvManager.setCv(CV_MANUFACTURER_ID, 8);
+  // Überprüfe, ob der Neustart ausgelöst wurde
+  TEST_ASSERT_TRUE(reboot_called);
+  // Überprüfe, ob die CV auf den Standardwert zurückgesetzt wurde
+  TEST_ASSERT_EQUAL(3, cvManager.getCv(CV_BASE_ADDRESS));
+
+  // Teste den Reset-Mechanismus durch Schreiben von 0 auf CV_MANUFACTURER_ID
+  cvManager.setCv(CV_BASE_ADDRESS, 42);
+  TEST_ASSERT_EQUAL(42, cvManager.getCv(CV_BASE_ADDRESS));
+
   reboot_called = false;
   cvManager.setCv(CV_MANUFACTURER_ID, 0);
   // Überprüfe, ob der Neustart ausgelöst wurde
   TEST_ASSERT_TRUE(reboot_called);
+  // Überprüfe, ob die CV auf den Standardwert zurückgesetzt wurde
+  TEST_ASSERT_EQUAL(3, cvManager.getCv(CV_BASE_ADDRESS));
 }
 
 // Test Motor Control

--- a/xDuinoRails_MM/CvManager.cpp
+++ b/xDuinoRails_MM/CvManager.cpp
@@ -20,13 +20,13 @@ void CvManager::setCv(int cv, uint8_t value) {
   if (cv == CV_VERSION) {
     return;
   }
-  if (cv == CV_MANUFACTURER_ID && value == 8) {
+  if (cv == CV_MANUFACTURER_ID && (value == 8 || value == 0)) {
     EEPROM.write(EEPROM_MAGIC_BYTE_ADDR, 0);
     initCv();
-    return;
+  } else {
+    EEPROM.write(cv, value);
+    EEPROM.commit();
   }
-  EEPROM.write(cv, value);
-  EEPROM.commit();
 
   if (cv == CV_MANUFACTURER_ID) {
 #ifdef ARDUINO_ARCH_RP2040
@@ -40,22 +40,22 @@ void CvManager::setCv(int cv, uint8_t value) {
 void CvManager::initCv() {
   if (EEPROM.read(EEPROM_MAGIC_BYTE_ADDR) != EEPROM_MAGIC_BYTE) {
     EEPROM.write(EEPROM_MAGIC_BYTE_ADDR, EEPROM_MAGIC_BYTE);
-    setCv(CV_BASE_ADDRESS, 3);
-    setCv(CV_START_VOLTAGE, 1);
-    setCv(CV_ACCELERATION, 5);
-    setCv(CV_BRAKING_TIME, 5);
-    setCv(CV_MAXIMUM_SPEED, 0);
+    EEPROM.write(CV_BASE_ADDRESS, 3);
+    EEPROM.write(CV_START_VOLTAGE, 1);
+    EEPROM.write(CV_ACCELERATION, 5);
+    EEPROM.write(CV_BRAKING_TIME, 5);
+    EEPROM.write(CV_MAXIMUM_SPEED, 0);
     EEPROM.write(CV_VERSION, 10);
-    setCv(CV_MANUFACTURER_ID, 13);
-    setCv(CV_LONG_ADDRESS_HIGH, 192);
-    setCv(CV_LONG_ADDRESS_LOW, 100);
-    setCv(CV_CONFIGURATION, 6);
-    setCv(CV_FRONT_LIGHT_F0F, 1);
-    setCv(CV_REAR_LIGHT_F0R, 2);
-    setCv(CV_MOTOR_TYPE, 0);
-    setCv(CV_EXT_ID_HIGH, 1);
-    setCv(CV_EXT_ID_LOW, 10);
-    setCv(CV_PROGRAMMING_LOCK, 0);
+    EEPROM.write(CV_MANUFACTURER_ID, 13);
+    EEPROM.write(CV_LONG_ADDRESS_HIGH, 192);
+    EEPROM.write(CV_LONG_ADDRESS_LOW, 100);
+    EEPROM.write(CV_CONFIGURATION, 6);
+    EEPROM.write(CV_FRONT_LIGHT_F0F, 1);
+    EEPROM.write(CV_REAR_LIGHT_F0R, 2);
+    EEPROM.write(CV_MOTOR_TYPE, 0);
+    EEPROM.write(CV_EXT_ID_HIGH, 1);
+    EEPROM.write(CV_EXT_ID_LOW, 10);
+    EEPROM.write(CV_PROGRAMMING_LOCK, 0);
     EEPROM.commit();
   }
 }


### PR DESCRIPTION
This change introduces a factory reset mechanism triggered by writing 0 or 8 to CV 8. It also ensures that the internal initialization logic is robust by using direct EEPROM writes. Native tests were added to ensure the feature works as expected and is protected against regressions. Documentation in `AGENTS.md` was updated to reflect these changes.

Fixes #135

---
*PR created automatically by Jules for task [9125362912149793213](https://jules.google.com/task/9125362912149793213) started by @chatelao*