### PR TITLE
Implement Factory Reset Logic via CV 8

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,3 +42,7 @@ AlignTrailingComments: true
 
 - **Dependency Injection:** For hardware configurations like pin numbers, use dependency injection by passing them into class constructors from a central configuration point (e.g., the main .ino file) rather than using global definitions via header files. This decouples classes from specific hardware setups.
 - **READMEs:** Add a basic `README.md` file to any new subdirectories to explain the purpose of the code within that directory.
+
+## Known Mechanisms
+
+- **CV 8 Reset:** Writing 0 or 8 to CV 8 (Manufacturer ID) triggers a factory reset and a hardware reboot. This feature must be covered by native tests in `test/test_native/`.

--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -68,6 +68,44 @@ void test_cv_manager_special(void) {
   TEST_ASSERT_TRUE(reboot_called);
 }
 
+// Testet den Reset-Mechanismus durch Schreiben des Wertes 0 auf CV 8.
+void test_cv_manager_reset(void) {
+  CvManager cvManager;
+  cvManager.setup();
+
+  // Ändere eine CV auf einen Nicht-Standardwert
+  cvManager.setCv(CV_BASE_ADDRESS, 42);
+  TEST_ASSERT_EQUAL(42, cvManager.getCv(CV_BASE_ADDRESS));
+
+  // Trigger Reset durch Schreiben von 0 auf CV 8
+  reboot_called = false;
+  cvManager.setCv(CV_MANUFACTURER_ID, 0);
+
+  // Überprüfe, ob reboot aufgerufen wurde
+  TEST_ASSERT_TRUE(reboot_called);
+  // Überprüfe, ob die CVs auf Standardwerte zurückgesetzt wurden
+  TEST_ASSERT_EQUAL(3, cvManager.getCv(CV_BASE_ADDRESS));
+}
+
+// Testet den Reset-Mechanismus durch Schreiben des Wertes 8 auf CV 8.
+void test_cv_manager_reset_alt(void) {
+  CvManager cvManager;
+  cvManager.setup();
+
+  // Ändere eine CV auf einen Nicht-Standardwert
+  cvManager.setCv(CV_BASE_ADDRESS, 42);
+  TEST_ASSERT_EQUAL(42, cvManager.getCv(CV_BASE_ADDRESS));
+
+  // Trigger Reset durch Schreiben von 8 auf CV 8
+  reboot_called = false;
+  cvManager.setCv(CV_MANUFACTURER_ID, 8);
+
+  // Überprüfe, ob reboot aufgerufen wurde
+  TEST_ASSERT_TRUE(reboot_called);
+  // Überprüfe, ob die CVs auf Standardwerte zurückgesetzt wurden
+  TEST_ASSERT_EQUAL(3, cvManager.getCv(CV_BASE_ADDRESS));
+}
+
 // Test Motor Control
 // Testet die Geschwindigkeits- und Richtungsteuerung des Motors.
 void test_motor_speed_control(void) {
@@ -315,6 +353,8 @@ int main(int argc, char **argv) {
   RUN_TEST(test_cv_manager_get_set);
   RUN_TEST(test_cv_manager_defaults);
   RUN_TEST(test_cv_manager_special);
+  RUN_TEST(test_cv_manager_reset);
+  RUN_TEST(test_cv_manager_reset_alt);
   RUN_TEST(test_motor_speed_control);
   RUN_TEST(test_lights_control_default_behavior);
   RUN_TEST(test_mm_signal_f0_f1_f2);

--- a/xDuinoRails_MM/CvManager.cpp
+++ b/xDuinoRails_MM/CvManager.cpp
@@ -20,13 +20,13 @@ void CvManager::setCv(int cv, uint8_t value) {
   if (cv == CV_VERSION) {
     return;
   }
-  if (cv == CV_MANUFACTURER_ID && value == 8) {
+  if (cv == CV_MANUFACTURER_ID && (value == 8 || value == 0)) {
     EEPROM.write(EEPROM_MAGIC_BYTE_ADDR, 0);
     initCv();
-    return;
+  } else {
+    EEPROM.write(cv, value);
+    EEPROM.commit();
   }
-  EEPROM.write(cv, value);
-  EEPROM.commit();
 
   if (cv == CV_MANUFACTURER_ID) {
 #ifdef ARDUINO_ARCH_RP2040
@@ -40,23 +40,23 @@ void CvManager::setCv(int cv, uint8_t value) {
 void CvManager::initCv() {
   if (EEPROM.read(EEPROM_MAGIC_BYTE_ADDR) != EEPROM_MAGIC_BYTE) {
     EEPROM.write(EEPROM_MAGIC_BYTE_ADDR, EEPROM_MAGIC_BYTE);
-    setCv(CV_BASE_ADDRESS, 3);
-    setCv(CV_START_VOLTAGE, 1);
-    setCv(CV_ACCELERATION, 5);
-    setCv(CV_BRAKING_TIME, 5);
-    setCv(CV_MAXIMUM_SPEED, 0);
+    EEPROM.write(CV_BASE_ADDRESS, 3);
+    EEPROM.write(CV_START_VOLTAGE, 1);
+    EEPROM.write(CV_ACCELERATION, 5);
+    EEPROM.write(CV_BRAKING_TIME, 5);
+    EEPROM.write(CV_MAXIMUM_SPEED, 0);
     EEPROM.write(CV_VERSION, 10);
-    setCv(CV_MANUFACTURER_ID, 13);
-    setCv(CV_WATCHDOG_TIMEOUT, 5);
-    setCv(CV_LONG_ADDRESS_HIGH, 192);
-    setCv(CV_LONG_ADDRESS_LOW, 100);
-    setCv(CV_CONFIGURATION, 6);
-    setCv(CV_FRONT_LIGHT_F0F, 1);
-    setCv(CV_REAR_LIGHT_F0R, 2);
-    setCv(CV_MOTOR_TYPE, 0);
-    setCv(CV_EXT_ID_HIGH, 1);
-    setCv(CV_EXT_ID_LOW, 10);
-    setCv(CV_PROGRAMMING_LOCK, 0);
+    EEPROM.write(CV_MANUFACTURER_ID, 13);
+    EEPROM.write(CV_WATCHDOG_TIMEOUT, 5);
+    EEPROM.write(CV_LONG_ADDRESS_HIGH, 192);
+    EEPROM.write(CV_LONG_ADDRESS_LOW, 100);
+    EEPROM.write(CV_CONFIGURATION, 6);
+    EEPROM.write(CV_FRONT_LIGHT_F0F, 1);
+    EEPROM.write(CV_REAR_LIGHT_F0R, 2);
+    EEPROM.write(CV_MOTOR_TYPE, 0);
+    EEPROM.write(CV_EXT_ID_HIGH, 1);
+    EEPROM.write(CV_EXT_ID_LOW, 10);
+    EEPROM.write(CV_PROGRAMMING_LOCK, 0);
     EEPROM.commit();
   }
 }


### PR DESCRIPTION
This change adds a factory reset mechanism to the `CvManager`. Writing the value 0 or 8 to CV 8 (Manufacturer ID) now triggers a reset of all Configuration Variables to their default values, followed by a hardware reboot. 

The `CvManager::initCv` method was also refactored to use direct `EEPROM.write` calls, preventing redundant reboots or recursive logic during the initialization process. 

To ensure reliability, two new native test cases were added to `test/test_native/test_main.cpp`, verifying that both trigger values correctly perform the reset and reboot. These tests are automatically executed in the CI/CD pipeline. 

Finally, `AGENTS.md` was updated to document this new mechanism and the requirement for maintaining test coverage.

Fixes #141

---
*PR created automatically by Jules for task [6714949078802130186](https://jules.google.com/task/6714949078802130186) started by @chatelao*