### PR TITLE
Add factory reset logic to CV 8 and update test coverage requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,4 +41,5 @@ AlignTrailingComments: true
 ```
 
 - **Dependency Injection:** For hardware configurations like pin numbers, use dependency injection by passing them into class constructors from a central configuration point (e.g., the main .ino file) rather than using global definitions via header files. This decouples classes from specific hardware setups.
+- **Test Coverage:** Every feature or logic change, such as the CV 8 reset mechanism, must be accompanied by native test cases in `test/test_native/` which are executed automatically in the CI/CD pipeline.
 - **READMEs:** Add a basic `README.md` file to any new subdirectories to explain the purpose of the code within that directory.

--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -10,6 +10,7 @@
 void test_mm_signal_f0_f1_f2(void);
 void test_cv_programming_6021(void);
 void test_watchdog_shutdown(void);
+void test_cv_manager_reset_8(void);
 
 // Mock implementation for RP2040 reboot
 bool   reboot_called = false;
@@ -61,11 +62,34 @@ void test_cv_manager_special(void) {
   // Der Wert sollte unverändert sein
   TEST_ASSERT_EQUAL(version, cvManager.getCv(CV_VERSION));
 
-  // Teste den Reset-Mechanismus durch Schreiben auf CV_MANUFACTURER_ID
+  // Teste den Reset-Mechanismus durch Schreiben von 0 auf CV_MANUFACTURER_ID
+  // Ändere einen Wert, um den Reset zu verifizieren
+  cvManager.setCv(CV_BASE_ADDRESS, 42);
+  TEST_ASSERT_EQUAL(42, cvManager.getCv(CV_BASE_ADDRESS));
+
   reboot_called = false;
   cvManager.setCv(CV_MANUFACTURER_ID, 0);
   // Überprüfe, ob der Neustart ausgelöst wurde
   TEST_ASSERT_TRUE(reboot_called);
+  // Überprüfe, ob die Werte zurückgesetzt wurden
+  TEST_ASSERT_EQUAL(3, cvManager.getCv(CV_BASE_ADDRESS));
+}
+
+// Testet den Reset-Mechanismus durch Schreiben von 8 auf CV_MANUFACTURER_ID.
+void test_cv_manager_reset_8(void) {
+  CvManager cvManager;
+  cvManager.setup();
+
+  // Ändere einen Wert, um den Reset zu verifizieren
+  cvManager.setCv(CV_BASE_ADDRESS, 42);
+  TEST_ASSERT_EQUAL(42, cvManager.getCv(CV_BASE_ADDRESS));
+
+  reboot_called = false;
+  cvManager.setCv(CV_MANUFACTURER_ID, 8);
+  // Überprüfe, ob der Neustart ausgelöst wurde
+  TEST_ASSERT_TRUE(reboot_called);
+  // Überprüfe, ob die Werte zurückgesetzt wurden
+  TEST_ASSERT_EQUAL(3, cvManager.getCv(CV_BASE_ADDRESS));
 }
 
 // Test Motor Control
@@ -315,6 +339,7 @@ int main(int argc, char **argv) {
   RUN_TEST(test_cv_manager_get_set);
   RUN_TEST(test_cv_manager_defaults);
   RUN_TEST(test_cv_manager_special);
+  RUN_TEST(test_cv_manager_reset_8);
   RUN_TEST(test_motor_speed_control);
   RUN_TEST(test_lights_control_default_behavior);
   RUN_TEST(test_mm_signal_f0_f1_f2);

--- a/xDuinoRails_MM/CvManager.cpp
+++ b/xDuinoRails_MM/CvManager.cpp
@@ -21,9 +21,15 @@ void CvManager::setCv(int cv, uint8_t value) {
   if (cv == CV_VERSION) {
     return;
   }
-  if (cv == CV_MANUFACTURER_ID && value == 8) {
+  if (cv == CV_MANUFACTURER_ID && (value == 0 || value == 8)) {
     EEPROM.write(EEPROM_MAGIC_BYTE_ADDR, 0);
     initCv();
+
+#ifdef ARDUINO_ARCH_RP2040
+    rp2040.reboot();
+#elif defined(ARDUINO_ARCH_ESP32)
+    ESP.restart();
+#endif
     return;
   }
   EEPROM.write(cv, value);
@@ -43,24 +49,24 @@ void CvManager::setCv(int cv, uint8_t value) {
 void CvManager::initCv() {
   if (EEPROM.read(EEPROM_MAGIC_BYTE_ADDR) != EEPROM_MAGIC_BYTE) {
     EEPROM.write(EEPROM_MAGIC_BYTE_ADDR, EEPROM_MAGIC_BYTE);
-    setCv(CV_BASE_ADDRESS, 3);
-    setCv(CV_START_VOLTAGE, 1);
-    setCv(CV_ACCELERATION, 5);
-    setCv(CV_BRAKING_TIME, 5);
-    setCv(CV_MAXIMUM_SPEED, 0);
+    EEPROM.write(CV_BASE_ADDRESS, 3);
+    EEPROM.write(CV_START_VOLTAGE, 1);
+    EEPROM.write(CV_ACCELERATION, 5);
+    EEPROM.write(CV_BRAKING_TIME, 5);
+    EEPROM.write(CV_MAXIMUM_SPEED, 0);
     EEPROM.write(CV_VERSION, 10);
-    setCv(CV_MANUFACTURER_ID, 13);
-    setCv(CV_WATCHDOG_TIMEOUT, 5);
-    setCv(CV_LONG_ADDRESS_HIGH, 192);
-    setCv(CV_LONG_ADDRESS_LOW, 100);
-    setCv(CV_CONFIGURATION, 6);
-    setCv(CV_FRONT_LIGHT_F0F, 1);
-    setCv(CV_REAR_LIGHT_F0R, 2);
-    setCv(CV_MOTOR_TYPE, 0);
-    setCv(CV_EXT_ID_HIGH, 1);
-    setCv(CV_EXT_ID_LOW, 10);
-    setCv(CV_PROGRAMMING_LOCK, 0);
-    setCv(CV_DEBUG_ENABLE, 0);
+    EEPROM.write(CV_MANUFACTURER_ID, 13);
+    EEPROM.write(CV_WATCHDOG_TIMEOUT, 5);
+    EEPROM.write(CV_LONG_ADDRESS_HIGH, 192);
+    EEPROM.write(CV_LONG_ADDRESS_LOW, 100);
+    EEPROM.write(CV_CONFIGURATION, 6);
+    EEPROM.write(CV_FRONT_LIGHT_F0F, 1);
+    EEPROM.write(CV_REAR_LIGHT_F0R, 2);
+    EEPROM.write(CV_MOTOR_TYPE, 0);
+    EEPROM.write(CV_EXT_ID_HIGH, 1);
+    EEPROM.write(CV_EXT_ID_LOW, 10);
+    EEPROM.write(CV_PROGRAMMING_LOCK, 0);
+    EEPROM.write(CV_DEBUG_ENABLE, 0);
     EEPROM.commit();
   }
 }


### PR DESCRIPTION
This PR implements the requested factory reset logic for the decoder. Writing either 0 or 8 to CV 8 (Manufacturer ID) now triggers a full reset of all CV values to their defaults, followed by a hardware reboot (RP2040 or ESP32). 

Key changes:
1.  **CvManager.cpp**: Updated `setCv` to handle the reset trigger. Refactored `initCv` to use direct EEPROM writes to ensure a clean initialization process.
2.  **test_main.cpp**: Added and updated unit tests to verify that both 0 and 8 trigger a reset and that the reboot flag is set correctly in the mock environment.
3.  **AGENTS.md**: Documented the requirement for native tests for all new features to ensure ongoing stability in the CI/CD pipeline.

All native tests passed, and builds for Seeed Xiao RP2040 and Seeed Xiao ESP32-C6 were successful.

Fixes #144

---
*PR created automatically by Jules for task [117115436233644545](https://jules.google.com/task/117115436233644545) started by @chatelao*