### PR TITLE
Enable Logging by Default

### DIFF
--- a/AUDIT_CV.md
+++ b/AUDIT_CV.md
@@ -20,6 +20,7 @@ This document tracks the implementation status of Configuration Variables (CVs) 
 | 34 | Rear Light (F0r) | ✅ Implemented | Bit 1 enables rear light output. |
 | 52 | Motor Type | ✅ Implemented | Selects motor characteristics profile in `MotorControl`. |
 | 107/108| Ext. ID | ⚠️ Initialized Only | Metadata for DecoderDB identification. |
+| 250 | Debug Enable | ✅ Implemented | 0 = Disabled, 1 = Enabled (default). |
 
 ## Motor Parameters Detail (CV 52)
 

--- a/LOGGING_AUDIT.md
+++ b/LOGGING_AUDIT.md
@@ -8,8 +8,8 @@ The logging system is centralized in the `Logger` class, providing a unified way
 
 ### Configuration
 Logging is controlled by **CV 250 (CV_DEBUG_ENABLE)**.
-- **Value 0:** Logging disabled (default).
-- **Value > 0:** Logging enabled.
+- **Value 0:** Logging disabled.
+- **Value > 0:** Logging enabled (default = 1).
 
 The `Logger` class caches the state of CV 250 during its initialization in `begin()` to minimize EEPROM/flash reads and ensure performance. A change to CV 250 typically requires a reboot to take effect (or re-initialization of the logger).
 

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -61,7 +61,7 @@ This table specifies the minimal supported Configuration Variables (CVs) for thi
 | 🏎️ | 52 | Motor Type | Standard | 0 | Selects the motor characteristics curve. 0 = Standard DC, 1 = Faulhaber, 2 = Maxon. |
 | 🆔 | 107 | Ext. ID (High) | Meta | 1 | Identifier for DecoderDB (part 1 of ID 266). |
 | 🆔 | 108 | Ext. ID (Low) | Meta | 10 | Identifier for DecoderDB (part 2 of ID 266). |
-| 🪵 | 250 | Debug Enable | Standard | 0 | 0 = Disabled, 1 = Enabled. Outputs debug info to Serial USB. |
+| 🪵 | 250 | Debug Enable | Standard | 1 | 0 = Disabled, 1 = Enabled (default). Outputs debug info to Serial USB. |
 
 ### Programming Guide
 

--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -47,6 +47,7 @@ void test_cv_manager_defaults(void) {
   TEST_ASSERT_EQUAL(2, cvManager.getCv(CV_REAR_LIGHT_F0R));
   TEST_ASSERT_EQUAL(1, cvManager.getCv(CV_EXT_ID_HIGH));
   TEST_ASSERT_EQUAL(10, cvManager.getCv(CV_EXT_ID_LOW));
+  TEST_ASSERT_EQUAL(1, cvManager.getCv(CV_DEBUG_ENABLE));
 }
 
 // Testet spezielle CV-Funktionen wie schreibgeschützte CVs und den

--- a/xDuinoRails_MM/CvManager.cpp
+++ b/xDuinoRails_MM/CvManager.cpp
@@ -66,7 +66,7 @@ void CvManager::initCv() {
     EEPROM.write(CV_EXT_ID_HIGH, 1);
     EEPROM.write(CV_EXT_ID_LOW, 10);
     EEPROM.write(CV_PROGRAMMING_LOCK, 0);
-    EEPROM.write(CV_DEBUG_ENABLE, 0);
+    EEPROM.write(CV_DEBUG_ENABLE, 1);
     EEPROM.commit();
   }
 }


### PR DESCRIPTION
Enabled logging by default in the xDuinoRails_MM firmware by changing the default value of CV 250 (Debug Enable) to 1. This ensures that new installations and factory-reset devices will output debug information via Serial USB by default.

Key changes:
- Modified `xDuinoRails_MM/CvManager.cpp` to set the default EEPROM value for CV 250 to 1.
- Updated `test/test_native/test_main.cpp` to include an assertion for the new CV 250 default.
- Updated the documentation in `USER_MANUAL.md`, `AUDIT_CV.md`, and `LOGGING_AUDIT.md` to reflect that logging is now enabled by default.
- Verified the changes with `pio test -e native` and successful builds for both RP2040 and ESP32 targets.

Fixes #151

---
*PR created automatically by Jules for task [13790576815541895375](https://jules.google.com/task/13790576815541895375) started by @chatelao*