### PR TITLE
Add logging for startup and state changes

### DIFF
--- a/test/mocks/Arduino.h
+++ b/test/mocks/Arduino.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <map>
 #include <string>
+#include <vector>
 
 extern std::map<uint8_t, int> analog_write_values;
 extern std::map<uint8_t, int> digital_write_values;
@@ -30,11 +31,13 @@ long          map(long, long, long, long, long);
 
 class MockSerial {
 public:
-  void begin(unsigned long baud);
-  void print(const char *s);
-  void print(int n);
-  void println(const char *s);
-  void println(int n);
+  void                     begin(unsigned long baud);
+  void                     print(const char *s);
+  void                     print(int n);
+  void                     println(const char *s);
+  void                     println(int n);
+  void                     clearLog();
+  std::vector<std::string> logLines;
 };
 
 extern MockSerial Serial;

--- a/test/test_native/Arduino.cpp
+++ b/test/test_native/Arduino.cpp
@@ -47,7 +47,20 @@ long map(long x, long in_min, long in_max, long out_min, long out_max) {
 MockSerial Serial;
 
 void MockSerial::begin(unsigned long baud) {}
-void MockSerial::print(const char *s) { printf("%s", s); }
-void MockSerial::print(int n) { printf("%d", n); }
-void MockSerial::println(const char *s) { printf("%s\n", s); }
-void MockSerial::println(int n) { printf("%d\n", n); }
+void MockSerial::print(const char *s) {
+  printf("%s", s);
+  logLines.push_back(std::string(s));
+}
+void MockSerial::print(int n) {
+  printf("%d", n);
+  logLines.push_back(std::to_string(n));
+}
+void MockSerial::println(const char *s) {
+  printf("%s\n", s);
+  logLines.push_back(std::string(s));
+}
+void MockSerial::println(int n) {
+  printf("%d\n", n);
+  logLines.push_back(std::to_string(n));
+}
+void MockSerial::clearLog() { logLines.clear(); }

--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -2,6 +2,7 @@
 #include "CvManagerMock.h"
 #include "CvProgrammer.h"
 #include "LightsControl.h"
+#include "Logger.h"
 #include "MotorControl.h"
 #include "ProtocolHandler.h"
 #include "RP2040.h"
@@ -12,6 +13,7 @@ void test_cv_programming_6021(void);
 void test_watchdog_shutdown(void);
 void test_cv_manager_reset_8(void);
 void test_motor_speed_curve(void);
+void test_logging(void);
 
 // Mock implementation for RP2040 reboot
 bool   reboot_called = false;
@@ -277,6 +279,78 @@ void test_watchdog_shutdown(void) {
   TEST_ASSERT_EQUAL(1023, analog_write_values[10]);
 }
 
+void test_logging(void) {
+  CvManagerMock cvManager;
+  cvManager.setCv(CV_DEBUG_ENABLE, 1);
+  logger.begin(&cvManager);
+  Serial.clearLog();
+
+  ProtocolHandler protocol(0);
+  protocol.setAddress(1);
+
+  // Test state change logging
+  protocol.mm.SetData(1, 5, true, false, false, MM2DirectionState_Forward, 0,
+                      false);
+  protocol.loop();
+
+  bool foundStateLog = false;
+  for (const auto &line : Serial.logLines) {
+    if (line.find("State: Addr=1, Speed=5") != std::string::npos) {
+      foundStateLog = true;
+      break;
+    }
+  }
+  TEST_ASSERT_TRUE(foundStateLog);
+  Serial.clearLog();
+
+  // Test redundant packet (no log)
+  protocol.mm.SetData(1, 5, true, false, false, MM2DirectionState_Forward, 0,
+                      false);
+  protocol.loop();
+  TEST_ASSERT_EQUAL(0, Serial.logLines.size());
+
+  // Test signal lost
+  advance_millis(600); // Default timeout is 500ms
+  protocol.loop();
+  bool foundSignalLost = false;
+  for (const auto &line : Serial.logLines) {
+    if (line.find("MM Signal lost") != std::string::npos) {
+      foundSignalLost = true;
+      break;
+    }
+  }
+  TEST_ASSERT_TRUE(foundSignalLost);
+  Serial.clearLog();
+
+  // Test signal recovered
+  protocol.mm.SetData(1, 5, true, false, false, MM2DirectionState_Forward, 0,
+                      false);
+  protocol.loop();
+  bool foundSignalRecovered = false;
+  for (const auto &line : Serial.logLines) {
+    if (line.find("MM Signal recovered") != std::string::npos) {
+      foundSignalRecovered = true;
+      break;
+    }
+  }
+  TEST_ASSERT_TRUE(foundSignalRecovered);
+  Serial.clearLog();
+
+  // Test Motor kickstart logging
+  MotorControl motor(cvManager, 10, 11, 2, 3);
+  motor.setup();
+  motor.setSpeed(1, MM2DirectionState_Forward);
+
+  bool foundKickstartStarted = false;
+  for (const auto &line : Serial.logLines) {
+    if (line.find("Motor: Kickstart started") != std::string::npos) {
+      foundKickstartStarted = true;
+      break;
+    }
+  }
+  TEST_ASSERT_TRUE(foundKickstartStarted);
+}
+
 void test_motor_speed_curve(void) {
   CvManagerMock cvManager;
 
@@ -392,5 +466,6 @@ int main(int argc, char **argv) {
   RUN_TEST(test_cv_programming_6021);
   RUN_TEST(test_watchdog_shutdown);
   RUN_TEST(test_motor_speed_curve);
+  RUN_TEST(test_logging);
   return UNITY_END();
 }

--- a/xDuinoRails_MM/MotorControl.cpp
+++ b/xDuinoRails_MM/MotorControl.cpp
@@ -1,4 +1,5 @@
 #include "MotorControl.h"
+#include "Logger.h"
 
 const int PWM_RANGE = 1023;
 
@@ -121,8 +122,9 @@ void MotorControl::update(int pwm, MM2DirectionState dir) {
 
   if (previousPwm == 0 && targetPwm > 0 && KICK_MAX_TIME > 0) {
     isKickstarting_priv = true;
-    kickstartBegin      = now;
-    lastBemfMeasure     = 0;
+    logger.println("Motor: Kickstart started");
+    kickstartBegin  = now;
+    lastBemfMeasure = 0;
   }
   if (targetPwm == 0) {
     isKickstarting_priv = false;
@@ -131,12 +133,14 @@ void MotorControl::update(int pwm, MM2DirectionState dir) {
   if (isKickstarting_priv) {
     if (now - kickstartBegin >= KICK_MAX_TIME) {
       isKickstarting_priv = false;
+      logger.println("Motor: Kickstart ended (timeout)");
     } else {
       if (now - lastBemfMeasure > BEMF_SAMPLE_INT) {
         int currentBEMF = readBEMF();
         lastBemfMeasure = now;
         if (currentBEMF > BEMF_THRESHOLD) {
           isKickstarting_priv = false;
+          logger.println("Motor: Kickstart ended (BEMF)");
         }
       }
       if (isKickstarting_priv) {

--- a/xDuinoRails_MM/ProtocolHandler.cpp
+++ b/xDuinoRails_MM/ProtocolHandler.cpp
@@ -22,6 +22,14 @@ ProtocolHandler::ProtocolHandler(int dccMmSignalPin)
   lastChangeDirInput  = false;
   lastChangeDirTs     = 0;
   lastSpeedChangeTs   = 0;
+
+  lastTargetSpeed     = 0;
+  lastTargetDirection = MM2DirectionState_Forward;
+  lastStateF0         = false;
+  lastStateF1         = false;
+  lastStateF2         = false;
+  wasMm2Locked        = false;
+  wasSignalTimeout    = false;
 }
 
 void ProtocolHandler::setup() {
@@ -43,13 +51,18 @@ void ProtocolHandler::loop() {
     lastSignalTime = now;
   }
 
+  bool signalTimeout = isSignalTimeout();
+  if (signalTimeout != wasSignalTimeout) {
+    if (signalTimeout) {
+      logger.println("MM Signal lost");
+    } else {
+      logger.println("MM Signal recovered");
+    }
+    wasSignalTimeout = signalTimeout;
+  }
+
   if (Data && !Data->IsMagnet && Data->Address == mmAddress) {
     lastCommandTime = now;
-
-    logger.printf("MM Packet: Addr=%d, Speed=%d, Dir=%s, F0=%d, MM2=%d\n",
-                  Data->Address, Data->Speed,
-                  Data->MM2Direction == MM2DirectionState_Forward ? "F" : "B",
-                  Data->Function, Data->IsMM2);
 
     bool mm2Locked = (lastMM2Seen > 0 && now - lastMM2Seen < mm2LockTime);
 
@@ -84,6 +97,24 @@ void ProtocolHandler::loop() {
     }
 
     stateF0 = Data->Function;
+
+    if (targetSpeed != lastTargetSpeed || targetDirection != lastTargetDirection ||
+        stateF0 != lastStateF0 || stateF1 != lastStateF1 ||
+        stateF2 != lastStateF2 || mm2Locked != wasMm2Locked) {
+
+      logger.printf("State: Addr=%d, Speed=%d, Dir=%s, F0=%d, F1=%d, F2=%d, "
+                    "MM2Lock=%d\n",
+                    mmAddress, targetSpeed,
+                    targetDirection == MM2DirectionState_Forward ? "F" : "B",
+                    stateF0, stateF1, stateF2, mm2Locked);
+
+      lastTargetSpeed     = targetSpeed;
+      lastTargetDirection = targetDirection;
+      lastStateF0         = stateF0;
+      lastStateF1         = stateF1;
+      lastStateF2         = stateF2;
+      wasMm2Locked        = mm2Locked;
+    }
   }
 }
 

--- a/xDuinoRails_MM/ProtocolHandler.h
+++ b/xDuinoRails_MM/ProtocolHandler.h
@@ -42,6 +42,15 @@ private:
   bool              lastChangeDirInput;
   unsigned long     lastChangeDirTs;
   unsigned long     lastSpeedChangeTs;
+
+  // Last reported states for logging
+  int               lastTargetSpeed;
+  MM2DirectionState lastTargetDirection;
+  bool              lastStateF0;
+  bool              lastStateF1;
+  bool              lastStateF2;
+  bool              wasMm2Locked;
+  bool              wasSignalTimeout;
 };
 
 #endif // PROTOCOL_HANDLER_H

--- a/xDuinoRails_MM/xDuinoRails_MM.ino
+++ b/xDuinoRails_MM/xDuinoRails_MM.ino
@@ -97,6 +97,11 @@ void setup() {
   cvManager.setup();
   logger.begin(&cvManager, 115200);
   logger.println("xDuinoRails_MM starting...");
+  logger.printf("Version: %d\n", cvManager.getCv(CV_VERSION));
+  logger.printf("Address: %d\n", cvManager.getCv(CV_BASE_ADDRESS));
+  logger.printf("Motor Type: %d\n", cvManager.getCv(CV_MOTOR_TYPE));
+  logger.printf("Watchdog: %d ms\n", cvManager.getCv(CV_WATCHDOG_TIMEOUT) * 100);
+
   protocol.setAddress(cvManager.getCv(1));
   protocol.setSignalTimeout(cvManager.getCv(CV_WATCHDOG_TIMEOUT) * 100);
   protocol.setup();


### PR DESCRIPTION
Implemented comprehensive logging for system startup, locomotive state transitions (speed, direction, functions F0-F2), protocol status (MM2 lock, signal loss/recovery), and motor activity (kickstart start/end). The logging is designed to be informative without being verbose by only outputting state transitions. Also updated the native test environment to support log verification and added a corresponding test case.

Fixes #154

---
*PR created automatically by Jules for task [9497066085612687283](https://jules.google.com/task/9497066085612687283) started by @chatelao*