### PR TITLE
Print current CV settings on bootup

### DIFF
--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -14,6 +14,7 @@ void test_watchdog_shutdown(void);
 void test_cv_manager_reset_8(void);
 void test_motor_speed_curve(void);
 void test_logging(void);
+void test_cv_manager_print_all(void);
 
 // Mock implementation for RP2040 reboot
 bool   reboot_called = false;
@@ -352,6 +353,45 @@ void test_logging(void) {
   TEST_ASSERT_TRUE(foundKickstartStarted);
 }
 
+void test_cv_manager_print_all(void) {
+  CvManager cvManager;
+  cvManager.setup();
+  cvManager.setCv(CV_DEBUG_ENABLE, 1);
+  logger.begin(&cvManager);
+  Serial.clearLog();
+
+  cvManager.printAllCvs();
+
+  bool foundHeader     = false;
+  bool foundAddress    = false;
+  bool foundVersion    = false;
+  bool foundFooter     = false;
+  bool foundLongAddr   = false;
+  bool foundExtId      = false;
+
+  for (const auto &line : Serial.logLines) {
+    if (line.find("--- Current CV Settings ---") != std::string::npos)
+      foundHeader = true;
+    if (line.find("CV 1 (Address): 3") != std::string::npos)
+      foundAddress = true;
+    if (line.find("CV 7 (Version): 10") != std::string::npos)
+      foundVersion = true;
+    if (line.find("CV 17/18 (Long Addr): 49252") != std::string::npos) // (192 << 8) | 100 = 49152 + 100 = 49252
+      foundLongAddr = true;
+    if (line.find("CV 107/108 (Ext ID): 266") != std::string::npos) // (1 << 8) | 10 = 256 + 10 = 266
+      foundExtId = true;
+    if (line.find("---------------------------") != std::string::npos)
+      foundFooter = true;
+  }
+
+  TEST_ASSERT_TRUE(foundHeader);
+  TEST_ASSERT_TRUE(foundAddress);
+  TEST_ASSERT_TRUE(foundVersion);
+  TEST_ASSERT_TRUE(foundLongAddr);
+  TEST_ASSERT_TRUE(foundExtId);
+  TEST_ASSERT_TRUE(foundFooter);
+}
+
 void test_motor_speed_curve(void) {
   CvManagerMock cvManager;
 
@@ -468,5 +508,6 @@ int main(int argc, char **argv) {
   RUN_TEST(test_watchdog_shutdown);
   RUN_TEST(test_motor_speed_curve);
   RUN_TEST(test_logging);
+  RUN_TEST(test_cv_manager_print_all);
   return UNITY_END();
 }

--- a/xDuinoRails_MM/CvManager.cpp
+++ b/xDuinoRails_MM/CvManager.cpp
@@ -46,6 +46,30 @@ void CvManager::setCv(int cv, uint8_t value) {
   }
 }
 
+void CvManager::printAllCvs() {
+  logger.println("--- Current CV Settings ---");
+  logger.printf("CV 1 (Address): %d\n", getCv(CV_BASE_ADDRESS));
+  logger.printf("CV 2 (Vstart): %d\n", getCv(CV_START_VOLTAGE));
+  logger.printf("CV 3 (Acc): %d\n", getCv(CV_ACCELERATION));
+  logger.printf("CV 4 (Dec): %d\n", getCv(CV_BRAKING_TIME));
+  logger.printf("CV 5 (Vhigh): %d\n", getCv(CV_MAXIMUM_SPEED));
+  logger.printf("CV 6 (Vmid): %d\n", getCv(CV_MEDIUM_SPEED));
+  logger.printf("CV 7 (Version): %d\n", getCv(CV_VERSION));
+  logger.printf("CV 8 (Manuf ID): %d\n", getCv(CV_MANUFACTURER_ID));
+  logger.printf("CV 11 (Watchdog): %d\n", getCv(CV_WATCHDOG_TIMEOUT));
+  logger.printf("CV 15 (Prog Lock): %d\n", getCv(CV_PROGRAMMING_LOCK));
+  logger.printf("CV 17/18 (Long Addr): %d\n",
+                (getCv(CV_LONG_ADDRESS_HIGH) << 8) | getCv(CV_LONG_ADDRESS_LOW));
+  logger.printf("CV 29 (Config): %d\n", getCv(CV_CONFIGURATION));
+  logger.printf("CV 33 (F0f): %d\n", getCv(CV_FRONT_LIGHT_F0F));
+  logger.printf("CV 34 (F0r): %d\n", getCv(CV_REAR_LIGHT_F0R));
+  logger.printf("CV 52 (Motor Type): %d\n", getCv(CV_MOTOR_TYPE));
+  logger.printf("CV 107/108 (Ext ID): %d\n",
+                (getCv(CV_EXT_ID_HIGH) << 8) | getCv(CV_EXT_ID_LOW));
+  logger.printf("CV 250 (Debug): %d\n", getCv(CV_DEBUG_ENABLE));
+  logger.println("---------------------------");
+}
+
 void CvManager::initCv() {
   if (EEPROM.read(EEPROM_MAGIC_BYTE_ADDR) != EEPROM_MAGIC_BYTE) {
     EEPROM.write(EEPROM_MAGIC_BYTE_ADDR, EEPROM_MAGIC_BYTE);

--- a/xDuinoRails_MM/CvManager.h
+++ b/xDuinoRails_MM/CvManager.h
@@ -30,6 +30,7 @@ public:
   virtual void    setup();
   virtual uint8_t getCv(int cv);
   virtual void    setCv(int cv, uint8_t value);
+  virtual void    printAllCvs();
 
 private:
   void initCv();

--- a/xDuinoRails_MM/xDuinoRails_MM.ino
+++ b/xDuinoRails_MM/xDuinoRails_MM.ino
@@ -97,10 +97,7 @@ void setup() {
   cvManager.setup();
   logger.begin(&cvManager, 115200);
   logger.println("xDuinoRails_MM starting...");
-  logger.printf("Version: %d\n", cvManager.getCv(CV_VERSION));
-  logger.printf("Address: %d\n", cvManager.getCv(CV_BASE_ADDRESS));
-  logger.printf("Motor Type: %d\n", cvManager.getCv(CV_MOTOR_TYPE));
-  logger.printf("Watchdog: %d ms\n", cvManager.getCv(CV_WATCHDOG_TIMEOUT) * 100);
+  cvManager.printAllCvs();
 
   protocol.setAddress(cvManager.getCv(1));
   protocol.setSignalTimeout(cvManager.getCv(CV_WATCHDOG_TIMEOUT) * 100);


### PR DESCRIPTION
This change adds a summary of all current Configuration Variable (CV) settings to the serial output when the firmware starts.

Key changes:
- New `printAllCvs()` method in `CvManager` that iterates through and logs all implemented CVs.
- Multi-byte CVs (Long Address, Ext ID) are correctly combined for display.
- Consistently uses the `logger` system.
- Replaced individual CV logs in `setup()` with the comprehensive `printAllCvs()` call.
- Added a native unit test to verify the logging output formatting.

Fixes #159

---
*PR created automatically by Jules for task [16913693877355067119](https://jules.google.com/task/16913693877355067119) started by @chatelao*