### PR TITLE
Log motor type and PWM frequency changes

### DIFF
--- a/LOGGING_AUDIT.md
+++ b/LOGGING_AUDIT.md
@@ -35,6 +35,8 @@ The following areas of the codebase currently implement logging:
 | | Progress of direction change sequences (for entering programming mode). |
 | | Received CV addresses and values during programming. |
 | **Protocol Handler** | Decoded MM packet details: Address, Speed, Direction, F0 state, and MM2 status. |
+| **Motor Control** | Motor type and PWM frequency during `setup()`. |
+| | Kickstart events (start, timeout, BEMF). |
 
 ## Implementation Details
 

--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -15,6 +15,8 @@ void test_cv_manager_reset_8(void);
 void test_motor_speed_curve(void);
 void test_logging(void);
 void test_cv_manager_print_all(void);
+void test_motor_frequency_logging(void);
+void test_cv_motor_type_reboot(void);
 
 // Mock implementation for RP2040 reboot
 bool   reboot_called = false;
@@ -353,6 +355,72 @@ void test_logging(void) {
   TEST_ASSERT_TRUE(foundKickstartStarted);
 }
 
+void test_motor_frequency_logging(void) {
+  CvManagerMock cvManager;
+  cvManager.setCv(CV_DEBUG_ENABLE, 1);
+  logger.begin(&cvManager);
+
+  // Case 1: Standard DC (default)
+  {
+    Serial.clearLog();
+    cvManager.setCv(CV_MOTOR_TYPE, 0);
+    MotorControl motor(cvManager, 10, 11, 2, 3);
+    motor.setup();
+    bool found = false;
+    for (const auto &line : Serial.logLines) {
+      if (line.find("Motor: Type=Standard DC, PWM Freq=20000 Hz") !=
+          std::string::npos) {
+        found = true;
+        break;
+      }
+    }
+    TEST_ASSERT_TRUE(found);
+  }
+
+  // Case 2: Faulhaber
+  {
+    Serial.clearLog();
+    cvManager.setCv(CV_MOTOR_TYPE, 1);
+    MotorControl motor(cvManager, 10, 11, 2, 3);
+    motor.setup();
+    bool found = false;
+    for (const auto &line : Serial.logLines) {
+      if (line.find("Motor: Type=Faulhaber, PWM Freq=400 Hz") !=
+          std::string::npos) {
+        found = true;
+        break;
+      }
+    }
+    TEST_ASSERT_TRUE(found);
+  }
+
+  // Case 3: Maxon
+  {
+    Serial.clearLog();
+    cvManager.setCv(CV_MOTOR_TYPE, 2);
+    MotorControl motor(cvManager, 10, 11, 2, 3);
+    motor.setup();
+    bool found = false;
+    for (const auto &line : Serial.logLines) {
+      if (line.find("Motor: Type=Maxon, PWM Freq=20000 Hz") !=
+          std::string::npos) {
+        found = true;
+        break;
+      }
+    }
+    TEST_ASSERT_TRUE(found);
+  }
+}
+
+void test_cv_motor_type_reboot(void) {
+  CvManager cvManager;
+  cvManager.setup();
+
+  reboot_called = false;
+  cvManager.setCv(CV_MOTOR_TYPE, 1);
+  TEST_ASSERT_TRUE(reboot_called);
+}
+
 void test_cv_manager_print_all(void) {
   CvManager cvManager;
   cvManager.setup();
@@ -508,6 +576,8 @@ int main(int argc, char **argv) {
   RUN_TEST(test_watchdog_shutdown);
   RUN_TEST(test_motor_speed_curve);
   RUN_TEST(test_logging);
+  RUN_TEST(test_motor_frequency_logging);
+  RUN_TEST(test_cv_motor_type_reboot);
   RUN_TEST(test_cv_manager_print_all);
   return UNITY_END();
 }

--- a/xDuinoRails_MM/CvManager.cpp
+++ b/xDuinoRails_MM/CvManager.cpp
@@ -37,7 +37,7 @@ void CvManager::setCv(int cv, uint8_t value) {
 
   logger.printf("CV %d set to %d\n", cv, value);
 
-  if (cv == CV_MANUFACTURER_ID) {
+  if (cv == CV_MANUFACTURER_ID || cv == CV_MOTOR_TYPE) {
 #ifdef ARDUINO_ARCH_RP2040
     rp2040.reboot();
 #elif defined(ARDUINO_ARCH_ESP32)

--- a/xDuinoRails_MM/MotorControl.cpp
+++ b/xDuinoRails_MM/MotorControl.cpp
@@ -55,6 +55,15 @@ void MotorControl::setup() {
   pinMode(bemfA_priv, INPUT);
   pinMode(bemfB_priv, INPUT);
 
+  int         motorType = cvManager.getCv(CV_MOTOR_TYPE);
+  const char *typeName;
+  switch (motorType) {
+  case 1: typeName = "Faulhaber"; break;
+  case 2: typeName = "Maxon"; break;
+  default: typeName = "Standard DC"; break;
+  }
+  logger.printf("Motor: Type=%s, PWM Freq=%d Hz\n", typeName, PWM_FREQ);
+
 #ifdef ARDUINO_ARCH_RP2040
   analogWriteFreq(PWM_FREQ);
   analogWriteRange(PWM_RANGE);


### PR DESCRIPTION
This change implements logging of the PWM frequency whenever it is set or changed. Since the PWM frequency is determined by the motor type (CV 52), the firmware now triggers a reboot when this CV is modified. Upon reboot, the new motor type and its corresponding PWM frequency are logged during the hardware initialization in `MotorControl::setup()`.

Key changes:
- `MotorControl::setup()` now logs: `Motor: Type=[Type], PWM Freq=[Freq] Hz`.
- `CvManager::setCv()` now includes `CV_MOTOR_TYPE` in the list of CVs that trigger a hardware reboot.
- Native tests `test_motor_frequency_logging` and `test_cv_motor_type_reboot` were added to verify the implementation.
- `LOGGING_AUDIT.md` was updated to document these new logging points.

Fixes #162

---
*PR created automatically by Jules for task [15749068924828712737](https://jules.google.com/task/15749068924828712737) started by @chatelao*