### PR TITLE
Log PWM frequency changes via motor type reboot

### DIFF
--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -283,6 +283,73 @@ void test_watchdog_shutdown(void) {
   TEST_ASSERT_EQUAL(1023, analog_write_values[10]);
 }
 
+void test_pwm_freq_logging(void) {
+  CvManagerMock cvManager;
+  cvManager.setCv(CV_DEBUG_ENABLE, 1);
+  logger.begin(&cvManager);
+
+  // Test Standard DC (Type 0)
+  cvManager.setCv(CV_MOTOR_TYPE, 0);
+  Serial.clearLog();
+  {
+    MotorControl motor(cvManager, 10, 11, 2, 3);
+    motor.setup();
+    bool found = false;
+    for (const auto &line : Serial.logLines) {
+      if (line.find("Motor: Type=Standard DC, PWM Freq=20000 Hz") !=
+          std::string::npos) {
+        found = true;
+        break;
+      }
+    }
+    TEST_ASSERT_TRUE(found);
+  }
+
+  // Test Faulhaber (Type 1)
+  cvManager.setCv(CV_MOTOR_TYPE, 1);
+  Serial.clearLog();
+  {
+    MotorControl motor(cvManager, 10, 11, 2, 3);
+    motor.setup();
+    bool found = false;
+    for (const auto &line : Serial.logLines) {
+      if (line.find("Motor: Type=Faulhaber, PWM Freq=400 Hz") !=
+          std::string::npos) {
+        found = true;
+        break;
+      }
+    }
+    TEST_ASSERT_TRUE(found);
+  }
+
+  // Test Maxon (Type 2)
+  cvManager.setCv(CV_MOTOR_TYPE, 2);
+  Serial.clearLog();
+  {
+    MotorControl motor(cvManager, 10, 11, 2, 3);
+    motor.setup();
+    bool found = false;
+    for (const auto &line : Serial.logLines) {
+      if (line.find("Motor: Type=Maxon, PWM Freq=20000 Hz") !=
+          std::string::npos) {
+        found = true;
+        break;
+      }
+    }
+    TEST_ASSERT_TRUE(found);
+  }
+}
+
+void test_cv_motor_type_reboot(void) {
+  CvManager cvManager;
+  cvManager.setup();
+
+  reboot_called = false;
+  cvManager.setCv(CV_MOTOR_TYPE, 1);
+  TEST_ASSERT_TRUE(reboot_called);
+  TEST_ASSERT_EQUAL(1, cvManager.getCv(CV_MOTOR_TYPE));
+}
+
 void test_logging(void) {
   CvManagerMock cvManager;
   cvManager.setCv(CV_DEBUG_ENABLE, 1);
@@ -438,6 +505,7 @@ void test_motor_speed_curve(void) {
   cvManager.setCv(CV_MAXIMUM_SPEED, 200);
   cvManager.setCv(CV_MEDIUM_SPEED, 0);
   MotorControl motor1(cvManager, 10, 11, 2, 3);
+  motor1.setup();
 
   motor1.setSpeed(1, MM2DirectionState_Forward);
   advance_millis(101);
@@ -546,6 +614,8 @@ int main(int argc, char **argv) {
   RUN_TEST(test_watchdog_shutdown);
   RUN_TEST(test_motor_speed_curve);
   RUN_TEST(test_logging);
+  RUN_TEST(test_pwm_freq_logging);
+  RUN_TEST(test_cv_motor_type_reboot);
   RUN_TEST(test_serial_console);
   RUN_TEST(test_cv_manager_print_all);
   return UNITY_END();

--- a/xDuinoRails_MM/CvManager.cpp
+++ b/xDuinoRails_MM/CvManager.cpp
@@ -37,7 +37,7 @@ void CvManager::setCv(int cv, uint8_t value) {
 
   logger.printf("CV %d set to %d\n", cv, value);
 
-  if (cv == CV_MANUFACTURER_ID) {
+  if (cv == CV_MANUFACTURER_ID || cv == CV_MOTOR_TYPE) {
 #ifdef ARDUINO_ARCH_RP2040
     rp2040.reboot();
 #elif defined(ARDUINO_ARCH_ESP32)

--- a/xDuinoRails_MM/MotorControl.cpp
+++ b/xDuinoRails_MM/MotorControl.cpp
@@ -18,35 +18,6 @@ MotorControl::MotorControl(CvManager &cvManager, int pinA, int pinB, int bemfA,
   lastBemfMeasure     = 0;
   lastSpeed           = 0;
   previousPwm         = 0;
-
-  int motorType = cvManager.getCv(CV_MOTOR_TYPE);
-
-  switch (motorType) {
-  case 1: // Faulhaber
-    PWM_FREQ = 400;
-    // PWM_MIN_MOVING is set from CV
-    KICK_PWM        = 1023;
-    KICK_MAX_TIME   = 150;
-    BEMF_THRESHOLD  = 120;
-    BEMF_SAMPLE_INT = 15;
-    break;
-  case 2: // Maxon
-    PWM_FREQ = 20000;
-    // PWM_MIN_MOVING is set from CV
-    KICK_PWM        = 600;
-    KICK_MAX_TIME   = 80;
-    BEMF_THRESHOLD  = 80;
-    BEMF_SAMPLE_INT = 10;
-    break;
-  default: // Standard DC
-    PWM_FREQ = 20000;
-    // PWM_MIN_MOVING is set from CV
-    KICK_PWM        = 800;
-    KICK_MAX_TIME   = 100;
-    BEMF_THRESHOLD  = 100;
-    BEMF_SAMPLE_INT = 12;
-    break;
-  }
 }
 
 void MotorControl::setup() {
@@ -54,6 +25,38 @@ void MotorControl::setup() {
   pinMode(pinB_priv, OUTPUT);
   pinMode(bemfA_priv, INPUT);
   pinMode(bemfB_priv, INPUT);
+
+  int         motorType = cvManager.getCv(CV_MOTOR_TYPE);
+  const char *typeName  = "Standard DC";
+
+  switch (motorType) {
+  case 1: // Faulhaber
+    PWM_FREQ        = 400;
+    KICK_PWM        = 1023;
+    KICK_MAX_TIME   = 150;
+    BEMF_THRESHOLD  = 120;
+    BEMF_SAMPLE_INT = 15;
+    typeName        = "Faulhaber";
+    break;
+  case 2: // Maxon
+    PWM_FREQ        = 20000;
+    KICK_PWM        = 600;
+    KICK_MAX_TIME   = 80;
+    BEMF_THRESHOLD  = 80;
+    BEMF_SAMPLE_INT = 10;
+    typeName        = "Maxon";
+    break;
+  default: // Standard DC
+    PWM_FREQ        = 20000;
+    KICK_PWM        = 800;
+    KICK_MAX_TIME   = 100;
+    BEMF_THRESHOLD  = 100;
+    BEMF_SAMPLE_INT = 12;
+    typeName        = "Standard DC";
+    break;
+  }
+
+  logger.printf("Motor: Type=%s, PWM Freq=%d Hz\n", typeName, PWM_FREQ);
 
 #ifdef ARDUINO_ARCH_RP2040
   analogWriteFreq(PWM_FREQ);


### PR DESCRIPTION
Implemented logging of PWM frequency and motor type by moving initialization to `MotorControl::setup()` and triggering a reboot when the motor type CV is changed. Added corresponding native tests.

Fixes #165

---
*PR created automatically by Jules for task [2313569218829729910](https://jules.google.com/task/2313569218829729910) started by @chatelao*