### PR TITLE
Log calculated PWM values in MotorControl::setSpeed

### DIFF
--- a/LOGGING_AUDIT.md
+++ b/LOGGING_AUDIT.md
@@ -35,6 +35,11 @@ The following areas of the codebase currently implement logging:
 | | Progress of direction change sequences (for entering programming mode). |
 | | Received CV addresses and values during programming. |
 | **Protocol Handler** | Decoded MM packet details: Address, Speed, Direction, F0 state, and MM2 status. |
+| | Signal presence transitions ("MM Signal lost" and "MM Signal recovered"). |
+| **Motor Control** | "Motor: Type=[Type], PWM Freq=[Freq] Hz" (Logged at startup). |
+| | "Motor: Step [Step] -> PWM [PWM], Dir [Dir]" (Logged on speed or direction change). |
+| | "Motor: Kickstart started" (Logged when starting from speed 0). |
+| | "Motor: Kickstart ended (timeout)" or "Motor: Kickstart ended (BEMF)". |
 
 ## Implementation Details
 

--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -422,6 +422,35 @@ void test_logging(void) {
     }
   }
   TEST_ASSERT_TRUE(foundKickstartStarted);
+  Serial.clearLog();
+
+  // Test Motor PWM logging
+  motor.setSpeed(7, MM2DirectionState_Forward);
+  bool foundPwmLog = false;
+  for (const auto &line : Serial.logLines) {
+    if (line.find("Motor: Step 7 -> PWM") != std::string::npos) {
+      foundPwmLog = true;
+      break;
+    }
+  }
+  TEST_ASSERT_TRUE(foundPwmLog);
+  Serial.clearLog();
+
+  // Test redundant call (no log)
+  motor.setSpeed(7, MM2DirectionState_Forward);
+  TEST_ASSERT_EQUAL(0, Serial.logLines.size());
+
+  // Test direction change log
+  motor.setSpeed(7, MM2DirectionState_Backward);
+  foundPwmLog = false;
+  for (const auto &line : Serial.logLines) {
+    if (line.find("Motor: Step 7 -> PWM") != std::string::npos &&
+        line.find("Dir Backward") != std::string::npos) {
+      foundPwmLog = true;
+      break;
+    }
+  }
+  TEST_ASSERT_TRUE(foundPwmLog);
 }
 
 void test_serial_console(void) {

--- a/xDuinoRails_MM/MotorControl.cpp
+++ b/xDuinoRails_MM/MotorControl.cpp
@@ -75,6 +75,11 @@ const int PWM_MAX = 1023;
 
 void MotorControl::setSpeed(int step, MM2DirectionState dir) {
   if (step == 0) {
+    if (lastSpeed != 0 || dir != targetDirection) {
+      logger.printf("Motor: Step 0 -> PWM 0, Dir %s\n",
+                    dir == MM2DirectionState_Forward ? "Forward" : "Backward");
+      lastSpeed = 0;
+    }
     update(0, dir);
     return;
   }
@@ -109,6 +114,12 @@ void MotorControl::setSpeed(int step, MM2DirectionState dir) {
     pwm = map(step, 1, 7, vStart, vMid);
   } else {
     pwm = map(step, 7, 14, vMid, vHigh);
+  }
+
+  if (step != lastSpeed || dir != targetDirection) {
+    logger.printf("Motor: Step %d -> PWM %d, Dir %s\n", step, pwm,
+                  dir == MM2DirectionState_Forward ? "Forward" : "Backward");
+    lastSpeed = step;
   }
 
   update(pwm, dir);


### PR DESCRIPTION
This change adds logging for calculated PWM values in the `MotorControl::setSpeed` function. To avoid flooding the serial console, differential logging is used, meaning a log entry is only generated when the speed step or direction actually changes.

Key changes:
- Modified `MotorControl::setSpeed` in `xDuinoRails_MM/MotorControl.cpp` to include the logging logic.
- Updated `LOGGING_AUDIT.md` to document the new PWM logging and include previously missing log entries for signal presence and motor state transitions.
- Enhanced `test/test_native/test_main.cpp` with new assertions in the `test_logging` suite to verify that PWM values are logged correctly and that redundant calls do not produce duplicate logs.
- Verified all native tests pass.

Fixes #172

---
*PR created automatically by Jules for task [3675542154744575868](https://jules.google.com/task/3675542154744575868) started by @chatelao*