### PR TITLE
Fix motor speed defaulting logic order

### DIFF
--- a/xDuinoRails_MM/MotorControl.cpp
+++ b/xDuinoRails_MM/MotorControl.cpp
@@ -100,8 +100,8 @@ void MotorControl::setSpeed(int step, MM2DirectionState dir) {
 
   // If CVs are 0, then set defaults (1 / PWM_MAX)
   if (vStart == 0) vStart = 1;
-  if (vMid   == 0) vMid = (vStart + vHigh) / 2;
   if (vHigh  == 0) vHigh = PWM_MAX;
+  if (vMid   == 0) vMid = (vStart + vHigh) / 2;
 
   // Clamp vStart to vHigh to avoid negative slopes
   if (vStart > vHigh)


### PR DESCRIPTION
Fixed a logic error in `MotorControl::setSpeed` where the default value for `vMid` was calculated using an un-defaulted `vHigh` value of 0. By reordering the assignments, `vHigh` is now correctly defaulted to `PWM_MAX` before being used to calculate the default midpoint for `vMid`. This change was verified by running the native test suite, specifically `test_motor_pwm_mapping_detailed` which now passes.

Fixes #185

---
*PR created automatically by Jules for task [17807869711143674416](https://jules.google.com/task/17807869711143674416) started by @chatelao*