### PR TITLE
Add CLI command to toggle logging on/off

### DIFF
--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -23,6 +23,7 @@ void test_motor_pwm_mapping_detailed(void);
 void test_motor_pwm_mapping_new_defaults(void);
 void test_debug_leds_heartbeat(void);
 void test_motor_bemf_pi_control(void);
+void test_serial_console_logging_toggle(void);
 
 // Mock implementation for RP2040 reboot
 bool   reboot_called = false;
@@ -665,6 +666,30 @@ void test_motor_speed_curve(void) {
   TEST_ASSERT_INT_WITHIN(2, 421, analog_write_values[10]);
 }
 
+void test_serial_console_logging_toggle(void) {
+  CvManagerMock   cvManager;
+  ProtocolHandler protocol(0);
+  protocol.setAddress(1);
+  SerialConsole console(&cvManager, &protocol);
+
+  // Initial state (enabled by default)
+  cvManager.setCv(CV_DEBUG_ENABLE, 1);
+  logger.begin(&cvManager);
+  TEST_ASSERT_TRUE(logger.isLoggingEnabled());
+
+  // Toggle OFF
+  Serial.pushInput("L\n");
+  console.loop();
+  TEST_ASSERT_FALSE(logger.isLoggingEnabled());
+  TEST_ASSERT_EQUAL(0, cvManager.getCv(CV_DEBUG_ENABLE));
+
+  // Toggle ON (using lowercase 'l')
+  Serial.pushInput("l\n");
+  console.loop();
+  TEST_ASSERT_TRUE(logger.isLoggingEnabled());
+  TEST_ASSERT_EQUAL(1, cvManager.getCv(CV_DEBUG_ENABLE));
+}
+
 void test_cv_programming_6021(void) {
   CvManagerMock   cvManager;
   ProtocolHandler protocol(0);
@@ -748,5 +773,6 @@ int main(int argc, char **argv) {
   RUN_TEST(test_motor_pwm_mapping_new_defaults);
   RUN_TEST(test_debug_leds_heartbeat);
   RUN_TEST(test_motor_bemf_pi_control);
+  RUN_TEST(test_serial_console_logging_toggle);
   return UNITY_END();
 }

--- a/xDuinoRails_MM/Logger.cpp
+++ b/xDuinoRails_MM/Logger.cpp
@@ -11,10 +11,17 @@ void Logger::begin(CvManager *cvManager, unsigned long baudRate) {
   this->cvManager = cvManager;
   cachedEnabled   = isEnabled();
   isInitialized   = true;
-  if (cachedEnabled) {
-    Serial.begin(baudRate);
+  Serial.begin(baudRate);
+}
+
+void Logger::toggleLogging() {
+  cachedEnabled = !cachedEnabled;
+  if (cvManager) {
+    cvManager->setCv(CV_DEBUG_ENABLE, cachedEnabled ? 1 : 0);
   }
 }
+
+bool Logger::isLoggingEnabled() { return cachedEnabled; }
 
 bool Logger::isEnabled() {
   if (cvManager == nullptr)

--- a/xDuinoRails_MM/Logger.h
+++ b/xDuinoRails_MM/Logger.h
@@ -11,6 +11,8 @@ public:
   void print(const char *message);
   void println(const char *message);
   void printf(const char *format, ...);
+  void toggleLogging();
+  bool isLoggingEnabled();
 
 private:
   CvManager *cvManager;

--- a/xDuinoRails_MM/SerialConsole.cpp
+++ b/xDuinoRails_MM/SerialConsole.cpp
@@ -47,5 +47,9 @@ void SerialConsole::parseCommand(char *line) {
     // We assume Function 1 as per request "f 0 : disable function 1", "f 1 : enable function 1"
     protocol->setFunctionState(1, val1 > 0);
     logger.printf("Serial: Function 1 set to %d\n", val1 > 0);
+  } else if (line[0] == 'L' || line[0] == 'l') {
+    logger.toggleLogging();
+    Serial.print("Serial: Logging ");
+    Serial.println(logger.isLoggingEnabled() ? "ON" : "OFF");
   }
 }


### PR DESCRIPTION
This change implements a runtime toggle for the logging system via the Serial CLI. By sending 'L' or 'l' through the serial console, users can now enable or disable debugging output without needing to reboot the decoder or manually change CVs via a programmer.

Key changes:
1. **Logger Initialization**: `Logger::begin()` now always calls `Serial.begin()`. This ensures that the command-line interface is always available, even if logging is initially disabled by `CV_DEBUG_ENABLE`.
2. **Toggle Logic**: A new `toggleLogging()` method was added to the `Logger` class. It flips the current `cachedEnabled` state and persists the new setting to `CV_DEBUG_ENABLE` (CV 250).
3. **CLI Integration**: The `SerialConsole` now recognizes 'L' and 'l' as commands to trigger the toggle. It provides immediate feedback to the user on the serial line (e.g., "Serial: Logging ON").
4. **Testing**: A new native test was added to `test_main.cpp` to verify that the CLI command correctly updates both the runtime state and the underlying CV.

Fixes #192

---
*PR created automatically by Jules for task [5882023549441924113](https://jules.google.com/task/5882023549441924113) started by @chatelao*