### PR TITLE
Add 'cv' command for CV readout in SerialConsole

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -82,6 +82,7 @@ The decoder provides a simple command line interface via the USB Serial port (11
 | Command | Description | Example |
 |---|---|---|
 | `cv <num> <val>` | Sets Configuration Variable `<num>` to value `<val>`. | `cv 1 3` (Sets address to 3) |
+| `cv` | Reads out all current Configuration Variable values. | `cv` |
 | `s <speed>` | Sets the target speed (0–14). | `s 7` (Half speed) |
 | `d f` | Sets the direction to **Forward**. | `d f` |
 | `d b` | Sets the direction to **Backward**. | `d b` |

--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -16,6 +16,7 @@ void test_cv_manager_reset_8(void);
 void test_motor_speed_curve(void);
 void test_logging(void);
 void test_serial_console(void);
+void test_serial_console_cv_readout(void);
 void test_cv_manager_print_all(void);
 void test_motor_kickstart_bemf_disabled(void);
 void test_motor_kickstart_bemf_enabled(void);
@@ -496,6 +497,32 @@ void test_serial_console(void) {
   TEST_ASSERT_FALSE(protocol.getFunctionState(1));
 }
 
+void test_serial_console_cv_readout(void) {
+  CvManagerMock   cvManager;
+  ProtocolHandler protocol(0);
+  protocol.setAddress(1);
+  SerialConsole console(&cvManager, &protocol);
+
+  cvManager.setCv(CV_DEBUG_ENABLE, 1);
+  logger.begin(&cvManager);
+  Serial.clearLog();
+
+  // Test "cv" command for readout
+  Serial.pushInput("cv\n");
+  console.loop();
+
+  bool foundHeader = false;
+  bool foundAddress = false;
+  for (const auto &line : Serial.logLines) {
+    if (line.find("--- Current CV Settings ---") != std::string::npos)
+      foundHeader = true;
+    if (line.find("CV 1 (Address): 3") != std::string::npos)
+      foundAddress = true;
+  }
+  TEST_ASSERT_TRUE(foundHeader);
+  TEST_ASSERT_TRUE(foundAddress);
+}
+
 void test_cv_manager_print_all(void) {
   CvManager cvManager;
   cvManager.setup();
@@ -766,6 +793,7 @@ int main(int argc, char **argv) {
   RUN_TEST(test_pwm_freq_logging);
   RUN_TEST(test_cv_motor_type_reboot);
   RUN_TEST(test_serial_console);
+  RUN_TEST(test_serial_console_cv_readout);
   RUN_TEST(test_cv_manager_print_all);
   RUN_TEST(test_motor_kickstart_bemf_disabled);
   RUN_TEST(test_motor_kickstart_bemf_enabled);

--- a/xDuinoRails_MM/SerialConsole.cpp
+++ b/xDuinoRails_MM/SerialConsole.cpp
@@ -32,6 +32,8 @@ void SerialConsole::parseCommand(char *line) {
   if (sscanf(line, "cv %d %d", &val1, &val2) == 2) {
     cvManager->setCv(val1, (uint8_t)val2);
     logger.printf("Serial: CV %d set to %d\n", val1, val2);
+  } else if (strcmp(line, "cv") == 0) {
+    cvManager->printAllCvs();
   } else if (sscanf(line, "s %d", &val1) == 1) {
     protocol->setTargetSpeed(val1);
     logger.printf("Serial: Speed set to %d\n", val1);


### PR DESCRIPTION
This change adds a new command to the Serial Command Line Interface. By typing `cv` and pressing Enter, the user can now read out all current Configuration Variable (CV) settings directly from the USB Serial port.

Changes:
- `xDuinoRails_MM/SerialConsole.cpp`: Added logic to handle the `cv` command by calling `cvManager->printAllCvs()`.
- `USER_MANUAL.md`: Added the `cv` command to the "Available Commands" table.
- `test/test_native/test_main.cpp`: Added a unit test to ensure the `cv` command correctly triggers the CV readout.

Verified with `pio test -e native`.

Fixes #197

---
*PR created automatically by Jules for task [2653929757972245388](https://jules.google.com/task/2653929757972245388) started by @chatelao*