### PR TITLE
Verify PWM scaling with BEMF disabled (CV 49)

### DIFF
--- a/test/test_native/test_cv49_verification.cpp
+++ b/test/test_native/test_cv49_verification.cpp
@@ -1,0 +1,80 @@
+#include "CvManagerMock.h"
+#include "MotorControl.h"
+#include <unity.h>
+#include <map>
+
+extern std::map<uint8_t, int> analog_write_values;
+extern void advance_millis(unsigned long ms);
+
+void test_cv49_bemf_disabled_pwm_scaling(void) {
+  CvManagerMock cvManager;
+  // CV 49 = 0 (BEMF disabled)
+  cvManager.setCv(CV_BEMF_CONFIG, 0);
+
+  // Set some CVs for scaling
+  // CV 2 = 20 (Vstart -> map(20, 0, 255, 0, 1023) = 80)
+  // CV 5 = 200 (Vhigh -> map(200, 0, 255, 0, 1023) = 802)
+  // CV 6 = 110 (Vmid -> map(110, 0, 255, 0, 1023) = 441)
+  cvManager.setCv(CV_START_VOLTAGE, 20);
+  cvManager.setCv(CV_MAXIMUM_SPEED, 200);
+  cvManager.setCv(CV_MEDIUM_SPEED, 110);
+  cvManager.setCv(CV_MOTOR_TYPE, 0);
+
+  MotorControl motor(cvManager, 10, 11, 2, 3);
+  motor.setup();
+
+  // Helper to get PWM after kickstart
+  auto get_pwm = [&](int step) {
+    motor.setSpeed(step, MM2DirectionState_Forward);
+    advance_millis(150); // Ensure kickstart is over
+    motor.setSpeed(step, MM2DirectionState_Forward);
+    return analog_write_values[10];
+  };
+
+  // Step 0: PWM 0
+  TEST_ASSERT_EQUAL(0, get_pwm(0));
+
+  // Step 1: Vstart = 80
+  TEST_ASSERT_EQUAL(80, get_pwm(1));
+
+  // Step 7: Vmid = 441
+  TEST_ASSERT_EQUAL(441, get_pwm(7));
+
+  // Step 14: Vhigh = 802
+  TEST_ASSERT_EQUAL(802, get_pwm(14));
+
+  // Intermediate Step 4: map(4, 1, 7, 80, 441) = 80 + (4-1)*(441-80)/6 = 80 + 3*361/6 = 80 + 180 = 260
+  TEST_ASSERT_EQUAL(260, get_pwm(4));
+
+  // Intermediate Step 10: map(10, 7, 14, 441, 802) = 441 + (10-7)*(802-441)/7 = 441 + 3*361/7 = 441 + 154 = 595
+  TEST_ASSERT_EQUAL(595, get_pwm(10));
+}
+
+void test_cv49_bemf_disabled_default_scaling(void) {
+  CvManagerMock cvManager;
+  cvManager.setCv(CV_BEMF_CONFIG, 0); // BEMF disabled
+
+  // Default values
+  cvManager.setCv(CV_START_VOLTAGE, 10);
+  cvManager.setCv(CV_MAXIMUM_SPEED, 0);
+  cvManager.setCv(CV_MEDIUM_SPEED, 0);
+  cvManager.setCv(CV_MOTOR_TYPE, 0);
+
+  MotorControl motor(cvManager, 10, 11, 2, 3);
+  motor.setup();
+
+  auto get_pwm = [&](int step) {
+    motor.setSpeed(step, MM2DirectionState_Forward);
+    advance_millis(150);
+    motor.setSpeed(step, MM2DirectionState_Forward);
+    return analog_write_values[10];
+  };
+
+  // vStart = map(10, 0, 255, 0, 1023) = 40
+  // vHigh = 0 -> PWM_RANGE = 1023
+  // vMid = 0 -> (vStart + vHigh) / 2 = (40 + 1023) / 2 = 531
+
+  TEST_ASSERT_EQUAL(40, get_pwm(1));
+  TEST_ASSERT_EQUAL(531, get_pwm(7));
+  TEST_ASSERT_EQUAL(1023, get_pwm(14));
+}

--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -25,6 +25,8 @@ void test_motor_pwm_mapping_new_defaults(void);
 void test_debug_leds_heartbeat(void);
 void test_motor_bemf_pi_control(void);
 void test_serial_console_logging_toggle(void);
+void test_cv49_bemf_disabled_pwm_scaling(void);
+void test_cv49_bemf_disabled_default_scaling(void);
 
 // Mock implementation for RP2040 reboot
 bool   reboot_called = false;
@@ -802,5 +804,7 @@ int main(int argc, char **argv) {
   RUN_TEST(test_debug_leds_heartbeat);
   RUN_TEST(test_motor_bemf_pi_control);
   RUN_TEST(test_serial_console_logging_toggle);
+  RUN_TEST(test_cv49_bemf_disabled_pwm_scaling);
+  RUN_TEST(test_cv49_bemf_disabled_default_scaling);
   return UNITY_END();
 }


### PR DESCRIPTION
I have verified that PWM scaling remains proportional to the speed set on the control and the scaling on CV 5/6 when BEMF is disabled via CV 49. 

To ensure this behavior is correctly implemented and remains stable, I added a new suite of native tests in `test/test_native/test_cv49_verification.cpp`. These tests:
1. Disable BEMF by setting CV 49 to 0.
2. Set specific values for CV 2 (Vstart), CV 5 (Vhigh), and CV 6 (Vmid).
3. Verify that the resulting PWM duty cycle for various speed steps (1-14) matches the expected values calculated from the piecewise linear speed curve.
4. Verify the behavior with default CV settings (CV 5/6 = 0).

All tests passed successfully in the native environment, confirming that the open-loop speed control (when BEMF is off) still correctly applies the configured speed curve scaling.

Fixes #200

---
*PR created automatically by Jules for task [10545871529155576818](https://jules.google.com/task/10545871529155576818) started by @chatelao*