### PR TITLE
Fix Motor Control state management and BEMF-disabled behavior

### DIFF
--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -25,6 +25,10 @@ void test_motor_pwm_mapping_new_defaults(void);
 void test_debug_leds_heartbeat(void);
 void test_motor_bemf_pi_control(void);
 void test_serial_console_logging_toggle(void);
+void test_repro_watchdog_stop_no_kickstart(void);
+void test_repro_start_backward_kickstart_wrong_dir(void);
+void test_repro_bemf_disabled_leftover_adjustment(void);
+void test_repro_direction_change_kickstart(void);
 
 // Mock implementation for RP2040 reboot
 bool   reboot_called = false;
@@ -137,10 +141,8 @@ void test_motor_speed_control(void) {
   motor.setSpeed(0, MM2DirectionState_Forward); // Erst anhalten
   motor.setSpeed(1, MM2DirectionState_Backward);
   advance_millis(101);
-  motor.setSpeed(1,
-                 MM2DirectionState_Backward); // Dieser Aufruf stoppt den Motor
-  motor.setSpeed(1,
-                 MM2DirectionState_Backward); // Dieser wendet die Leistung an
+  // Mit Korrektur wird hier direkt Kickstart ausgelöst und danach PWM gesetzt
+  motor.setSpeed(1, MM2DirectionState_Backward);
   TEST_ASSERT_EQUAL(LOW, digital_write_values[10]);
   TEST_ASSERT_EQUAL(40, analog_write_values[11]);
 
@@ -156,8 +158,7 @@ void test_motor_speed_control(void) {
   motor.setSpeed(0, MM2DirectionState_Forward);
   motor.setSpeed(14, MM2DirectionState_Backward);
   advance_millis(101);
-  motor.setSpeed(14, MM2DirectionState_Backward); // Stoppt den Motor
-  motor.setSpeed(14, MM2DirectionState_Backward); // Wendet Leistung an
+  motor.setSpeed(14, MM2DirectionState_Backward);
   TEST_ASSERT_EQUAL(LOW, digital_write_values[10]);
   TEST_ASSERT_EQUAL(1023, analog_write_values[11]);
 }
@@ -290,6 +291,13 @@ void test_watchdog_shutdown(void) {
                       MM2DirectionState_Unavailable, 0, false);
   protocol.loop();
   TEST_ASSERT_FALSE(protocol.isSignalTimeout());
+  simulate_loop();
+
+  // With kickstart triggered after stop(), PWM will be KICK_PWM (800) instead of 1023
+  TEST_ASSERT_EQUAL(800, analog_write_values[10]);
+
+  // After kickstart timeout, it should reach 1023
+  advance_millis(150);
   simulate_loop();
   TEST_ASSERT_EQUAL(1023, analog_write_values[10]);
 }
@@ -802,5 +810,9 @@ int main(int argc, char **argv) {
   RUN_TEST(test_debug_leds_heartbeat);
   RUN_TEST(test_motor_bemf_pi_control);
   RUN_TEST(test_serial_console_logging_toggle);
+  RUN_TEST(test_repro_watchdog_stop_no_kickstart);
+  RUN_TEST(test_repro_start_backward_kickstart_wrong_dir);
+  RUN_TEST(test_repro_bemf_disabled_leftover_adjustment);
+  RUN_TEST(test_repro_direction_change_kickstart);
   return UNITY_END();
 }

--- a/test/test_native/test_motor_state.cpp
+++ b/test/test_native/test_motor_state.cpp
@@ -1,0 +1,119 @@
+#include "CvManagerMock.h"
+#include "MotorControl.h"
+#include "RP2040.h"
+#include <unity.h>
+#include <map>
+
+extern std::map<uint8_t, int> analog_write_values;
+extern void advance_millis(unsigned long ms);
+
+void test_repro_watchdog_stop_no_kickstart(void) {
+  CvManagerMock cvManager;
+  cvManager.setCv(CV_BEMF_CONFIG, 0);
+  cvManager.setCv(CV_START_VOLTAGE, 10);
+  cvManager.setCv(CV_MOTOR_TYPE, 0);
+
+  MotorControl motor(cvManager, 10, 11, 2, 3);
+  motor.setup();
+
+  // 1. Start moving
+  motor.setSpeed(7, MM2DirectionState_Forward);
+  advance_millis(150); // Finish kickstart
+  motor.setSpeed(7, MM2DirectionState_Forward);
+  TEST_ASSERT_EQUAL(531, analog_write_values[10]);
+
+  // 2. Watchdog triggers stop()
+  motor.stop();
+  TEST_ASSERT_EQUAL(0, analog_write_values[10]);
+
+  // 3. Signal recovered, try to move again
+  motor.setSpeed(7, MM2DirectionState_Forward);
+
+  // FIX: It SHOULD kickstart because it was physically stopped.
+  TEST_ASSERT_TRUE(motor.isKickstarting());
+}
+
+void test_repro_start_backward_kickstart_wrong_dir(void) {
+  CvManagerMock cvManager;
+  cvManager.setCv(CV_MOTOR_TYPE, 0); // KICK_PWM = 800
+
+  MotorControl motor(cvManager, 10, 11, 2, 3);
+  motor.setup();
+
+  // Start moving Backward from standstill
+  motor.setSpeed(7, MM2DirectionState_Backward);
+
+  // FIX: It SHOULD kickstart in Backward direction (Pin 11)
+  TEST_ASSERT_TRUE(motor.isKickstarting());
+  TEST_ASSERT_EQUAL(800, analog_write_values[11]);
+  TEST_ASSERT_EQUAL(0, analog_write_values[10]);
+}
+
+void test_repro_bemf_disabled_leftover_adjustment(void) {
+  CvManagerMock cvManager;
+  cvManager.setCv(CV_START_VOLTAGE, 10);
+  cvManager.setCv(CV_MEDIUM_SPEED, 0);
+  cvManager.setCv(CV_MAXIMUM_SPEED, 255);
+  cvManager.setCv(CV_BEMF_CONFIG, 1);     // Enable BEMF initially
+  cvManager.setCv(CV_BEMF_K, 32);
+  cvManager.setCv(CV_BEMF_I, 0);
+  cvManager.setCv(CV_MOTOR_TYPE, 0);
+
+  MotorControl motor(cvManager, 10, 11, 2, 3);
+  motor.setup();
+
+  // Set speed to step 7 (targetPwm = 531)
+  motor.setSpeed(7, MM2DirectionState_Forward);
+  advance_millis(150); // Pass kickstart
+
+  // targetBEMF = 531 * 4 = 2124
+  // Simulate currentBEMF = 2000
+  // error = 124
+  // adjustment = (124 * 32 / 16) = 248
+  analog_read_values[2] = 2000;
+  analog_read_values[3] = 0;
+  advance_millis(20);
+  motor.setSpeed(7, MM2DirectionState_Forward);
+
+  // finalPwm = 531 + 248 = 779
+  TEST_ASSERT_EQUAL(779, analog_write_values[10]);
+
+  // Now disable BEMF via CV
+  cvManager.setCv(CV_BEMF_CONFIG, 0);
+
+  // Update again
+  motor.setSpeed(7, MM2DirectionState_Forward);
+
+  // FIX: adjustment should now be 0, so PWM should be 531
+  TEST_ASSERT_EQUAL(531, analog_write_values[10]);
+}
+
+void test_repro_direction_change_kickstart(void) {
+  CvManagerMock cvManager;
+  cvManager.setCv(CV_BEMF_CONFIG, 0);
+  cvManager.setCv(CV_START_VOLTAGE, 10);
+  cvManager.setCv(CV_MOTOR_TYPE, 0);
+
+  MotorControl motor(cvManager, 10, 11, 2, 3);
+  motor.setup();
+
+  // Start moving Forward
+  motor.setSpeed(7, MM2DirectionState_Forward);
+  advance_millis(150); // Finish kickstart
+  motor.setSpeed(7, MM2DirectionState_Forward);
+  TEST_ASSERT_EQUAL(531, analog_write_values[10]);
+
+  // Change direction to Backward while moving
+  motor.setSpeed(7, MM2DirectionState_Backward);
+
+  // Should stop first
+  TEST_ASSERT_EQUAL(0, analog_write_values[10]);
+  TEST_ASSERT_EQUAL(0, analog_write_values[11]);
+
+  // Next call should apply power in new direction AND kickstart
+  motor.setSpeed(7, MM2DirectionState_Backward);
+
+  // FIX: It SHOULD kickstart here because it just changed direction
+  TEST_ASSERT_TRUE(motor.isKickstarting());
+  TEST_ASSERT_EQUAL(800, analog_write_values[11]);
+}

--- a/xDuinoRails_MM/MotorControl.cpp
+++ b/xDuinoRails_MM/MotorControl.cpp
@@ -139,6 +139,7 @@ void MotorControl::update(int pwm, MM2DirectionState dir) {
 
   if (previousPwm == 0 && targetPwm > 0 && KICK_MAX_TIME > 0) {
     isKickstarting_priv = true;
+    currDirection       = targetDirection; // Ensure correct dir for kickstart
     logger.println("Motor: Kickstart started");
     kickstartBegin  = now;
     lastBemfMeasure = 0;
@@ -173,6 +174,7 @@ void MotorControl::update(int pwm, MM2DirectionState dir) {
       currDirection  = targetDirection;
       bemfErrorSum   = 0;
       lastAdjustment = 0;
+      targetPwm      = 0; // Force previousPwm to 0 for next call to trigger kickstart
     } else {
       int finalPwm = targetPwm;
 
@@ -202,6 +204,9 @@ void MotorControl::update(int pwm, MM2DirectionState dir) {
           lastAdjustment = (error * K / 16) + (bemfErrorSum * I / 64);
         }
         finalPwm += lastAdjustment;
+      } else {
+        lastAdjustment = 0;
+        bemfErrorSum   = 0;
       }
 
       writeMotorHardware(finalPwm, currDirection);
@@ -210,10 +215,7 @@ void MotorControl::update(int pwm, MM2DirectionState dir) {
   previousPwm = targetPwm;
 }
 
-void MotorControl::stop() {
-  targetPwm = 0;
-  writeMotorHardware(0, currDirection);
-}
+void MotorControl::stop() { update(0, currDirection); }
 
 bool MotorControl::isKickstarting() { return isKickstarting_priv; }
 


### PR DESCRIPTION
This submission fixes several issues in the motor control logic that caused the motor to stop responding correctly, especially when BEMF was disabled (CV 49 = 0). 

Key improvements:
- **State Reset on Stop:** `MotorControl::stop()` now calls `update(0, ...)` ensuring that `previousPwm` is reset. This allows the signal watchdog to stop the motor and have it correctly kickstart once the signal is recovered.
- **Immediate Direction Sync:** The motor now synchronizes its physical direction with the target direction at the very start of the kickstart phase, preventing it from briefly moving in the wrong direction.
- **BEMF Cleanup:** When BEMF is disabled, any leftover PI adjustments or integrated error sums are explicitly cleared, ensuring clean open-loop operation.
- **Direction Change Kickstart:** Changing direction while moving now correctly triggers a kickstart in the new direction.
- **Extended Test Suite:** A new test file `test/test_native/test_motor_state.cpp` has been added to provide permanent coverage for these edge cases. Existing tests were updated to align with the improved (and more predictable) state machine behavior.

All 27 native tests passed successfully.

Fixes #199

---
*PR created automatically by Jules for task [8780935455281174786](https://jules.google.com/task/8780935455281174786) started by @chatelao*