### PR TITLE
Add Architecture Diagram

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8,6 +8,12 @@ xDuinoRails_MM is a model train decoder firmware designed for the Seeed Xiao RP2
 
 The system is designed with a modular architecture that separates protocol decoding, motor control, lighting, and configuration management. This separation of concerns, combined with hardware abstraction layers, enables robust native testing on non-embedded platforms.
 
+## Architecture Diagram
+
+![Architecture Diagram](https://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/chatelao/xDuinoRails_MM/main/documentation/architecture.puml)
+
+*The diagram above is rendered dynamically from the [architecture.puml](documentation/architecture.puml) file.*
+
 ## Core Components
 
 The firmware is composed of several key modules, each responsible for a specific aspect of the decoder's functionality:

--- a/documentation/architecture.puml
+++ b/documentation/architecture.puml
@@ -1,0 +1,45 @@
+@startuml
+title xDuinoRails_MM Architecture Diagram
+
+package "Firmware Core" {
+    [ProtocolHandler] <<Module>>
+    [MotorControl] <<Module>>
+    [LightsControl] <<Module>>
+    [CvManager] <<Module>>
+    [CvProgrammer] <<Module>>
+    [SerialConsole] <<Module>>
+    [DebugLeds] <<Module>>
+    [Logger] <<Utility>>
+
+    [ProtocolHandler] -down-> [CvManager] : uses
+    [MotorControl] -down-> [CvManager] : uses
+    [LightsControl] -down-> [CvManager] : uses
+    [CvProgrammer] -right-> [CvManager] : modifies
+    [CvProgrammer] -left-> [ProtocolHandler] : monitors
+    [SerialConsole] -down-> [CvManager] : interacts
+    [SerialConsole] -down-> [ProtocolHandler] : interacts
+    [DebugLeds] -down-> [ProtocolHandler] : status
+    [DebugLeds] -down-> [MotorControl] : status
+
+    [ProtocolHandler] .up.> [Logger] : logs
+    [MotorControl] .up.> [Logger] : logs
+    [CvManager] .up.> [Logger] : logs
+}
+
+node "Hardware Abstraction / Peripherals" {
+    [MM Signal] --> [ProtocolHandler] : External Interrupt
+    [MotorControl] --> [Motor Output (PWM)]
+    [MotorControl] <-- [BEMF Input (ADC)]
+    [LightsControl] --> [Function Outputs]
+    [DebugLeds] --> [RGB LED / NeoPixel]
+    [CvManager] <--> [EEPROM / Flash]
+    [SerialConsole] <--> [USB Serial]
+    [Logger] --> [USB Serial]
+}
+
+legend right
+  Arrows indicate data flow or dependency.
+  Modules are high-level logic components.
+endlegend
+
+@enduml


### PR DESCRIPTION
I have added a PlantUML architecture diagram to the project.
The diagram is located in `documentation/architecture.puml` and provides a visual overview of the module interactions (ProtocolHandler, MotorControl, CvManager, etc.).
I have also updated `ARCHITECTURE.md` to include this diagram using a dynamic rendering link from the PlantUML proxy service, as well as a direct link to the source `.puml` file.
All native tests were run and passed to ensure project integrity.

Fixes #203

---
*PR created automatically by Jules for task [11123117645690713016](https://jules.google.com/task/11123117645690713016) started by @chatelao*