### PR TITLE
Extend logging CLI commands and implement categorized logging

### DIFF
--- a/test/test_native/test_logger_categories.cpp
+++ b/test/test_native/test_logger_categories.cpp
@@ -1,0 +1,103 @@
+#include "CvManagerMock.h"
+#include "Logger.h"
+#include "ProtocolHandler.h"
+#include "MotorControl.h"
+#include "SerialConsole.h"
+#include <unity.h>
+#include <string>
+#include <algorithm>
+
+void test_logger_categories(void) {
+  CvManagerMock cvManager;
+  cvManager.setCv(CV_DEBUG_ENABLE, 1);
+  logger.begin(&cvManager);
+
+  ProtocolHandler protocol(0);
+  protocol.setAddress(1);
+
+  MotorControl motor(cvManager, 10, 11, 2, 3);
+  motor.setup();
+
+  SerialConsole console(&cvManager, &protocol);
+
+  // 1. Initial State: All enabled
+  Serial.clearLog();
+  logger.printf(LogCategory::Protocol, "Protocol Message");
+  logger.printf(LogCategory::PWM, "PWM Message");
+  logger.printf(LogCategory::CV, "CV Message");
+  logger.printf(LogCategory::General, "General Message");
+
+  TEST_ASSERT_EQUAL(4, Serial.logLines.size());
+
+  // 2. Disable Protocol
+  Serial.clearLog();
+  Serial.pushInput("l p\n");
+  console.loop();
+
+  logger.printf(LogCategory::Protocol, "Protocol Hidden");
+  logger.printf(LogCategory::PWM, "PWM Visible");
+
+  bool foundProtocol = false;
+  bool foundPwm = false;
+  for (const auto& line : Serial.logLines) {
+      if (line.find("Protocol Hidden") != std::string::npos) foundProtocol = true;
+      if (line.find("PWM Visible") != std::string::npos) foundPwm = true;
+  }
+  TEST_ASSERT_FALSE(foundProtocol);
+  TEST_ASSERT_TRUE(foundPwm);
+
+  // 3. Disable PWM
+  Serial.clearLog();
+  Serial.pushInput("l w\n");
+  console.loop();
+
+  logger.printf(LogCategory::PWM, "PWM Hidden");
+  logger.printf(LogCategory::CV, "CV Visible");
+
+  bool foundPwmHidden = false;
+  bool foundCvVisible = false;
+  for (const auto& line : Serial.logLines) {
+      if (line.find("PWM Hidden") != std::string::npos) foundPwmHidden = true;
+      if (line.find("CV Visible") != std::string::npos) foundCvVisible = true;
+  }
+  TEST_ASSERT_FALSE(foundPwmHidden);
+  TEST_ASSERT_TRUE(foundCvVisible);
+
+  // 4. Disable CV
+  Serial.clearLog();
+  Serial.pushInput("l c\n");
+  console.loop();
+
+  logger.printf(LogCategory::CV, "CV Hidden");
+  logger.printf(LogCategory::General, "General Visible");
+
+  bool foundCvHidden = false;
+  bool foundGeneralVisible = false;
+  for (const auto& line : Serial.logLines) {
+      if (line.find("CV Hidden") != std::string::npos) foundCvHidden = true;
+      if (line.find("General Visible") != std::string::npos) foundGeneralVisible = true;
+  }
+  TEST_ASSERT_FALSE(foundCvHidden);
+  TEST_ASSERT_TRUE(foundGeneralVisible);
+
+  // 5. Re-enable all
+  Serial.pushInput("l p\n");
+  Serial.pushInput("l w\n");
+  Serial.pushInput("l c\n");
+  console.loop();
+
+  Serial.clearLog();
+  logger.printf(LogCategory::Protocol, "P");
+  logger.printf(LogCategory::PWM, "W");
+  logger.printf(LogCategory::CV, "C");
+  TEST_ASSERT_EQUAL(3, Serial.logLines.size());
+
+  // 6. Master Toggle
+  Serial.pushInput("l\n");
+  console.loop();
+  TEST_ASSERT_FALSE(logger.isLoggingEnabled());
+
+  Serial.clearLog();
+  logger.printf(LogCategory::General, "Should be hidden");
+  TEST_ASSERT_EQUAL(0, Serial.logLines.size());
+}

--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -15,6 +15,7 @@ void test_watchdog_shutdown(void);
 void test_cv_manager_reset_8(void);
 void test_motor_speed_curve(void);
 void test_logging(void);
+void test_logger_categories(void);
 void test_serial_console(void);
 void test_serial_console_cv_readout(void);
 void test_cv_manager_print_all(void);
@@ -798,6 +799,7 @@ int main(int argc, char **argv) {
   RUN_TEST(test_watchdog_shutdown);
   RUN_TEST(test_motor_speed_curve);
   RUN_TEST(test_logging);
+  RUN_TEST(test_logger_categories);
   RUN_TEST(test_pwm_freq_logging);
   RUN_TEST(test_cv_motor_type_reboot);
   RUN_TEST(test_serial_console);

--- a/xDuinoRails_MM/CvManager.cpp
+++ b/xDuinoRails_MM/CvManager.cpp
@@ -35,7 +35,7 @@ void CvManager::setCv(int cv, uint8_t value) {
   EEPROM.write(cv, value);
   EEPROM.commit();
 
-  logger.printf("CV %d set to %d\n", cv, value);
+  logger.printf(LogCategory::CV, "CV %d set to %d\n", cv, value);
 
   if (cv == CV_MANUFACTURER_ID || cv == CV_MOTOR_TYPE) {
 #ifdef ARDUINO_ARCH_RP2040
@@ -47,30 +47,33 @@ void CvManager::setCv(int cv, uint8_t value) {
 }
 
 void CvManager::printAllCvs() {
-  logger.println("--- Current CV Settings ---");
-  logger.printf("CV 1 (Address): %d\n", getCv(CV_BASE_ADDRESS));
-  logger.printf("CV 2 (Vstart): %d\n", getCv(CV_START_VOLTAGE));
-  logger.printf("CV 3 (Acc): %d\n", getCv(CV_ACCELERATION));
-  logger.printf("CV 4 (Dec): %d\n", getCv(CV_BRAKING_TIME));
-  logger.printf("CV 5 (Vhigh): %d\n", getCv(CV_MAXIMUM_SPEED));
-  logger.printf("CV 6 (Vmid): %d\n", getCv(CV_MEDIUM_SPEED));
-  logger.printf("CV 7 (Version): %d\n", getCv(CV_VERSION));
-  logger.printf("CV 8 (Manuf ID): %d\n", getCv(CV_MANUFACTURER_ID));
-  logger.printf("CV 11 (Watchdog): %d\n", getCv(CV_WATCHDOG_TIMEOUT));
-  logger.printf("CV 15 (Prog Lock): %d\n", getCv(CV_PROGRAMMING_LOCK));
-  logger.printf("CV 17/18 (Long Addr): %d\n",
+  logger.println("--- Current CV Settings ---", LogCategory::CV);
+  logger.printf(LogCategory::CV, "CV 1 (Address): %d\n", getCv(CV_BASE_ADDRESS));
+  logger.printf(LogCategory::CV, "CV 2 (Vstart): %d\n", getCv(CV_START_VOLTAGE));
+  logger.printf(LogCategory::CV, "CV 3 (Acc): %d\n", getCv(CV_ACCELERATION));
+  logger.printf(LogCategory::CV, "CV 4 (Dec): %d\n", getCv(CV_BRAKING_TIME));
+  logger.printf(LogCategory::CV, "CV 5 (Vhigh): %d\n", getCv(CV_MAXIMUM_SPEED));
+  logger.printf(LogCategory::CV, "CV 6 (Vmid): %d\n", getCv(CV_MEDIUM_SPEED));
+  logger.printf(LogCategory::CV, "CV 7 (Version): %d\n", getCv(CV_VERSION));
+  logger.printf(LogCategory::CV, "CV 8 (Manuf ID): %d\n", getCv(CV_MANUFACTURER_ID));
+  logger.printf(LogCategory::CV, "CV 11 (Watchdog): %d\n",
+                getCv(CV_WATCHDOG_TIMEOUT));
+  logger.printf(LogCategory::CV, "CV 15 (Prog Lock): %d\n",
+                getCv(CV_PROGRAMMING_LOCK));
+  logger.printf(LogCategory::CV, "CV 17/18 (Long Addr): %d\n",
                 (getCv(CV_LONG_ADDRESS_HIGH) << 8) | getCv(CV_LONG_ADDRESS_LOW));
-  logger.printf("CV 29 (Config): %d\n", getCv(CV_CONFIGURATION));
-  logger.printf("CV 33 (F0f): %d\n", getCv(CV_FRONT_LIGHT_F0F));
-  logger.printf("CV 34 (F0r): %d\n", getCv(CV_REAR_LIGHT_F0R));
-  logger.printf("CV 49 (BEMF Config): %d\n", getCv(CV_BEMF_CONFIG));
-  logger.printf("CV 54 (BEMF K): %d\n", getCv(CV_BEMF_K));
-  logger.printf("CV 55 (BEMF I): %d\n", getCv(CV_BEMF_I));
-  logger.printf("CV 52 (Motor Type): %d\n", getCv(CV_MOTOR_TYPE));
-  logger.printf("CV 107/108 (Ext ID): %d\n",
+  logger.printf(LogCategory::CV, "CV 29 (Config): %d\n", getCv(CV_CONFIGURATION));
+  logger.printf(LogCategory::CV, "CV 33 (F0f): %d\n", getCv(CV_FRONT_LIGHT_F0F));
+  logger.printf(LogCategory::CV, "CV 34 (F0r): %d\n", getCv(CV_REAR_LIGHT_F0R));
+  logger.printf(LogCategory::CV, "CV 49 (BEMF Config): %d\n",
+                getCv(CV_BEMF_CONFIG));
+  logger.printf(LogCategory::CV, "CV 54 (BEMF K): %d\n", getCv(CV_BEMF_K));
+  logger.printf(LogCategory::CV, "CV 55 (BEMF I): %d\n", getCv(CV_BEMF_I));
+  logger.printf(LogCategory::CV, "CV 52 (Motor Type): %d\n", getCv(CV_MOTOR_TYPE));
+  logger.printf(LogCategory::CV, "CV 107/108 (Ext ID): %d\n",
                 (getCv(CV_EXT_ID_HIGH) << 8) | getCv(CV_EXT_ID_LOW));
-  logger.printf("CV 250 (Debug): %d\n", getCv(CV_DEBUG_ENABLE));
-  logger.println("---------------------------");
+  logger.printf(LogCategory::CV, "CV 250 (Debug): %d\n", getCv(CV_DEBUG_ENABLE));
+  logger.println("---------------------------", LogCategory::CV);
 }
 
 void CvManager::initCv() {

--- a/xDuinoRails_MM/CvProgrammer.cpp
+++ b/xDuinoRails_MM/CvProgrammer.cpp
@@ -18,7 +18,8 @@ void CvProgrammer::loop() {
   if (lastChangeDirTs > 0 && lastChangeDirTs != lastDirectionChangeTime) {
     if (millis() - lastDirectionChangeTime < 2000) {
       directionChangeCount++;
-      logger.printf("Prog: ChangeDir count %d\n", directionChangeCount);
+      logger.printf(LogCategory::CV, "Prog: ChangeDir count %d\n",
+                    directionChangeCount);
     } else {
       directionChangeCount = 1;
     }
@@ -27,7 +28,7 @@ void CvProgrammer::loop() {
     if (directionChangeCount >= 4) {
       if (cvManager->getCv(CV_PROGRAMMING_LOCK) == 7) {
         programmingMode = !programmingMode;
-        logger.printf("Prog: Programming Mode %s\n",
+        logger.printf(LogCategory::CV, "Prog: Programming Mode %s\n",
                       programmingMode ? "Enabled" : "Disabled");
       }
       directionChangeCount = 0;
@@ -41,9 +42,11 @@ void CvProgrammer::loop() {
       int speed = protocolHandler->getTargetSpeed();
       if (cvAddress == -1) {
         cvAddress = speed;
-        logger.printf("Prog: CV Address %d received\n", cvAddress);
+        logger.printf(LogCategory::CV, "Prog: CV Address %d received\n",
+                      cvAddress);
       } else {
-        logger.printf("Prog: Writing CV %d = %d\n", cvAddress, speed);
+        logger.printf(LogCategory::CV, "Prog: Writing CV %d = %d\n", cvAddress,
+                      speed);
         cvManager->setCv(cvAddress, speed);
         cvAddress       = -1;
         programmingMode = false;

--- a/xDuinoRails_MM/Logger.cpp
+++ b/xDuinoRails_MM/Logger.cpp
@@ -5,7 +5,8 @@
 Logger logger;
 
 Logger::Logger()
-    : cvManager(nullptr), cachedEnabled(false), isInitialized(false) {}
+    : cvManager(nullptr), cachedEnabled(false), protocolEnabled(true),
+      pwmEnabled(true), cvEnabled(true), isInitialized(false) {}
 
 void Logger::begin(CvManager *cvManager, unsigned long baudRate) {
   this->cvManager = cvManager;
@@ -21,7 +22,36 @@ void Logger::toggleLogging() {
   }
 }
 
+void Logger::toggleCategory(LogCategory category) {
+  switch (category) {
+  case LogCategory::Protocol:
+    protocolEnabled = !protocolEnabled;
+    break;
+  case LogCategory::PWM:
+    pwmEnabled = !pwmEnabled;
+    break;
+  case LogCategory::CV:
+    cvEnabled = !cvEnabled;
+    break;
+  default:
+    break;
+  }
+}
+
 bool Logger::isLoggingEnabled() { return cachedEnabled; }
+
+bool Logger::isCategoryEnabled(LogCategory category) {
+  switch (category) {
+  case LogCategory::Protocol:
+    return protocolEnabled;
+  case LogCategory::PWM:
+    return pwmEnabled;
+  case LogCategory::CV:
+    return cvEnabled;
+  default:
+    return true;
+  }
+}
 
 bool Logger::isEnabled() {
   if (cvManager == nullptr)
@@ -29,20 +59,31 @@ bool Logger::isEnabled() {
   return cvManager->getCv(CV_DEBUG_ENABLE) != 0;
 }
 
-void Logger::print(const char *message) {
-  if (isInitialized && cachedEnabled) {
+void Logger::print(const char *message, LogCategory category) {
+  if (isInitialized && cachedEnabled && isCategoryEnabled(category)) {
     Serial.print(message);
   }
 }
 
-void Logger::println(const char *message) {
-  if (isInitialized && cachedEnabled) {
+void Logger::println(const char *message, LogCategory category) {
+  if (isInitialized && cachedEnabled && isCategoryEnabled(category)) {
     Serial.println(message);
   }
 }
 
+void Logger::printf(LogCategory category, const char *format, ...) {
+  if (isInitialized && cachedEnabled && isCategoryEnabled(category)) {
+    char    buf[128];
+    va_list args;
+    va_start(args, format);
+    vsnprintf(buf, sizeof(buf), format, args);
+    va_end(args);
+    Serial.print(buf);
+  }
+}
+
 void Logger::printf(const char *format, ...) {
-  if (isInitialized && cachedEnabled) {
+  if (isInitialized && cachedEnabled && isCategoryEnabled(LogCategory::General)) {
     char    buf[128];
     va_list args;
     va_start(args, format);

--- a/xDuinoRails_MM/Logger.h
+++ b/xDuinoRails_MM/Logger.h
@@ -4,20 +4,29 @@
 #include "CvManager.h"
 #include <Arduino.h>
 
+enum class LogCategory { General, Protocol, PWM, CV };
+
 class Logger {
 public:
   Logger();
   void begin(CvManager *cvManager, unsigned long baudRate = 115200);
-  void print(const char *message);
-  void println(const char *message);
-  void printf(const char *format, ...);
+  void print(const char *message, LogCategory category = LogCategory::General);
+  void println(const char *message,
+               LogCategory category = LogCategory::General);
+  void printf(LogCategory category, const char *format, ...);
+  void printf(const char *format, ...); // Overload for General
   void toggleLogging();
+  void toggleCategory(LogCategory category);
   bool isLoggingEnabled();
+  bool isCategoryEnabled(LogCategory category);
 
 private:
   CvManager *cvManager;
   bool       isEnabled();
   bool       cachedEnabled;
+  bool       protocolEnabled;
+  bool       pwmEnabled;
+  bool       cvEnabled;
   bool       isInitialized;
 };
 

--- a/xDuinoRails_MM/MotorControl.cpp
+++ b/xDuinoRails_MM/MotorControl.cpp
@@ -58,7 +58,8 @@ void MotorControl::setup() {
     break;
   }
 
-  logger.printf("Motor: Type=%s, PWM Freq=%d Hz\n", typeName, PWM_FREQ);
+  logger.printf(LogCategory::PWM, "Motor: Type=%s, PWM Freq=%d Hz\n", typeName,
+                PWM_FREQ);
 
 #ifdef ARDUINO_ARCH_RP2040
   analogWriteFreq(PWM_FREQ);
@@ -80,7 +81,7 @@ void MotorControl::setSpeed(int step, MM2DirectionState dir) {
   //
   if (step == 0) {
     if (lastSpeed != 0 || dir != targetDirection) {
-      logger.printf("Motor: Step 0 -> PWM 0, Dir %s\n",
+      logger.printf(LogCategory::PWM, "Motor: Step 0 -> PWM 0, Dir %s\n",
                     dir == MM2DirectionState_Forward ? "Forward" : "Backward");
       lastSpeed = 0;
     }
@@ -117,7 +118,8 @@ void MotorControl::setSpeed(int step, MM2DirectionState dir) {
   }
 
   if (step != lastSpeed || dir != targetDirection) {
-    logger.printf("Motor: Step %d -> PWM %d, Dir %s\n", step, pwm,
+    logger.printf(LogCategory::PWM, "Motor: Step %d -> PWM %d, Dir %s\n", step,
+                  pwm,
                   dir == MM2DirectionState_Forward ? "Forward" : "Backward");
     lastSpeed = step;
   }
@@ -140,7 +142,7 @@ void MotorControl::update(int pwm, MM2DirectionState dir) {
   if (previousPwm == 0 && targetPwm > 0 && KICK_MAX_TIME > 0) {
     isKickstarting_priv = true;
     currDirection       = targetDirection; // Ensure correct dir for kickstart
-    logger.println("Motor: Kickstart started");
+    logger.println("Motor: Kickstart started", LogCategory::PWM);
     kickstartBegin  = now;
     lastBemfMeasure = 0;
   }
@@ -151,7 +153,7 @@ void MotorControl::update(int pwm, MM2DirectionState dir) {
   if (isKickstarting_priv) {
     if (now - kickstartBegin >= KICK_MAX_TIME) {
       isKickstarting_priv = false;
-      logger.println("Motor: Kickstart ended (timeout)");
+      logger.println("Motor: Kickstart ended (timeout)", LogCategory::PWM);
     } else {
       bool bemfEnabled = (cvManager.getCv(CV_BEMF_CONFIG) & 0x01);
       if (bemfEnabled && (now - lastBemfMeasure > BEMF_SAMPLE_INT)) {
@@ -159,7 +161,7 @@ void MotorControl::update(int pwm, MM2DirectionState dir) {
         lastBemfMeasure = now;
         if (currentBEMF > BEMF_THRESHOLD) {
           isKickstarting_priv = false;
-          logger.println("Motor: Kickstart ended (BEMF)");
+          logger.println("Motor: Kickstart ended (BEMF)", LogCategory::PWM);
         }
       }
       if (isKickstarting_priv) {

--- a/xDuinoRails_MM/ProtocolHandler.cpp
+++ b/xDuinoRails_MM/ProtocolHandler.cpp
@@ -54,9 +54,9 @@ void ProtocolHandler::loop() {
   bool signalTimeout = isSignalTimeout();
   if (signalTimeout != wasSignalTimeout) {
     if (signalTimeout) {
-      logger.println("MM Signal lost");
+      logger.println("MM Signal lost", LogCategory::Protocol);
     } else {
-      logger.println("MM Signal recovered");
+      logger.println("MM Signal recovered", LogCategory::Protocol);
     }
     wasSignalTimeout = signalTimeout;
   }
@@ -104,7 +104,8 @@ void ProtocolHandler::loop() {
       stateF1 != lastStateF1 || stateF2 != lastStateF2 ||
       mm2Locked != wasMm2Locked) {
 
-    logger.printf("State: Addr=%d, Speed=%d, Dir=%s, F0=%d, F1=%d, F2=%d, "
+    logger.printf(LogCategory::Protocol,
+                  "State: Addr=%d, Speed=%d, Dir=%s, F0=%d, F1=%d, F2=%d, "
                   "MM2Lock=%d\n",
                   mmAddress, targetSpeed,
                   targetDirection == MM2DirectionState_Forward ? "F" : "B",

--- a/xDuinoRails_MM/SerialConsole.cpp
+++ b/xDuinoRails_MM/SerialConsole.cpp
@@ -50,8 +50,25 @@ void SerialConsole::parseCommand(char *line) {
     protocol->setFunctionState(1, val1 > 0);
     logger.printf("Serial: Function 1 set to %d\n", val1 > 0);
   } else if (line[0] == 'L' || line[0] == 'l') {
-    logger.toggleLogging();
-    Serial.print("Serial: Logging ");
-    Serial.println(logger.isLoggingEnabled() ? "ON" : "OFF");
+    if (line[1] == ' ' && line[2] != '\0') {
+      char sub = line[2];
+      if (sub == 'p') {
+        logger.toggleCategory(LogCategory::Protocol);
+        Serial.print("Serial: Protocol Logging ");
+        Serial.println(logger.isCategoryEnabled(LogCategory::Protocol) ? "ON" : "OFF");
+      } else if (sub == 'w') {
+        logger.toggleCategory(LogCategory::PWM);
+        Serial.print("Serial: PWM Logging ");
+        Serial.println(logger.isCategoryEnabled(LogCategory::PWM) ? "ON" : "OFF");
+      } else if (sub == 'c') {
+        logger.toggleCategory(LogCategory::CV);
+        Serial.print("Serial: CV Logging ");
+        Serial.println(logger.isCategoryEnabled(LogCategory::CV) ? "ON" : "OFF");
+      }
+    } else {
+      logger.toggleLogging();
+      Serial.print("Serial: Logging ");
+      Serial.println(logger.isLoggingEnabled() ? "ON" : "OFF");
+    }
   }
 }


### PR DESCRIPTION
This change introduces categorized logging to the firmware, allowing users to selectively enable or disable debug output for Protocol, PWM, and CV operations via the CLI.

Key changes:
- `Logger` class now supports `LogCategory`.
- `SerialConsole` parses `l p`, `l w`, and `l c` to toggle these categories.
- Existing log calls across the codebase have been updated to the appropriate categories.
- A new native test suite verifies the filtering logic and CLI integration.

Fixes #206

---
*PR created automatically by Jules for task [13076823549995029266](https://jules.google.com/task/13076823549995029266) started by @chatelao*