### PR TITLE
Add ESP32-C6 validation to CI/CD pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Test PlatformIO Project
         run: pio test -e native --without-uploading
 
+      - name: Build firmware
+        run: pio run -e seeed_xiao_rp2040 -e seeed_xiao_esp32c6
+
   arduino-cli-build:
     runs-on: ubuntu-latest
     steps:
@@ -38,12 +41,18 @@ jobs:
         run: |
           arduino-cli core update-index --additional-urls https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json
           arduino-cli core install rp2040:rp2040 --additional-urls https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json
+      - name: Install ESP32 Core
+        run: |
+          arduino-cli core update-index --additional-urls https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
+          arduino-cli core install esp32:esp32 --additional-urls https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
       - name: Install Libraries
         run: |
           arduino-cli lib install "Adafruit NeoPixel"
           arduino-cli lib install "MaerklinMotorola"
       - name: Compile
-        run: arduino-cli compile xDuinoRails_MM
+        run: |
+          arduino-cli compile --fqbn rp2040:rp2040:seeed_xiao_rp2040 xDuinoRails_MM
+          arduino-cli compile --fqbn esp32:esp32:XIAO_ESP32C6 xDuinoRails_MM
 
   release:
     needs: [build, arduino-cli-build]
@@ -65,9 +74,12 @@ jobs:
       - name: Install PlatformIO Core
         run: pip install --upgrade platformio
       - name: Build firmware
-        run: pio run -e seeed_xiao_rp2040
+        run: pio run -e seeed_xiao_rp2040 -e seeed_xiao_esp32c6
       - name: Upload release asset
         uses: AButler/upload-release-assets@v3.0
         with:
-          files: ".pio/build/seeed_xiao_rp2040/firmware.uf2"
+          files: |
+            .pio/build/seeed_xiao_rp2040/firmware.uf2
+            .pio/build/seeed_xiao_esp32c6/firmware.bin
+            .pio/build/seeed_xiao_esp32c6/firmware.factory.bin
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This change integrates full CI/CD support for the Seeed Studio XIAO ESP32-C6 platform. It ensures that every commit is validated for compilation using both PlatformIO and the Arduino CLI. Additionally, it automates the generation and attachment of ESP32-C6 firmware binaries (standard and factory) to repository releases alongside the existing RP2040 assets.

Fixes #205

---
*PR created automatically by Jules for task [10904792026872083106](https://jules.google.com/task/10904792026872083106) started by @chatelao*