### PR TITLE
Add BEMF and PWM telemetry logging

### DIFF
--- a/test/mocks/Arduino.h
+++ b/test/mocks/Arduino.h
@@ -43,6 +43,7 @@ public:
   int                      available();
   int                      read();
   size_t                   write(uint8_t c);
+  void                     printf(const char *format, ...);
   void                     pushInput(const std::string &s);
   std::vector<std::string> logLines;
   std::deque<char>         inputBuffer;

--- a/test/test_native/Arduino.cpp
+++ b/test/test_native/Arduino.cpp
@@ -87,6 +87,17 @@ size_t MockSerial::write(uint8_t c) {
   return 1;
 }
 
+#include <stdarg.h>
+void MockSerial::printf(const char *format, ...) {
+  char    buf[256];
+  va_list args;
+  va_start(args, format);
+  vsnprintf(buf, sizeof(buf), format, args);
+  va_end(args);
+  ::printf("%s", buf);
+  logLines.push_back(std::string(buf));
+}
+
 void MockSerial::pushInput(const std::string &s) {
   for (char c : s) {
     inputBuffer.push_back(c);

--- a/test/test_native/test_bemf_logging.cpp
+++ b/test/test_native/test_bemf_logging.cpp
@@ -1,0 +1,63 @@
+#include "CvManagerMock.h"
+#include "MotorControl.h"
+#include "Logger.h"
+#include "SerialConsole.h"
+#include <unity.h>
+
+extern std::map<uint8_t, int> analog_read_values;
+extern void advance_millis(unsigned long ms);
+
+void test_bemf_logging_toggle(void) {
+    CvManagerMock cvManager;
+    ProtocolHandler protocol(0);
+    SerialConsole console(&cvManager, &protocol);
+
+    cvManager.setCv(CV_DEBUG_ENABLE, 1);
+    logger.begin(&cvManager);
+
+    TEST_ASSERT_TRUE(logger.isBemfLoggingEnabled());
+
+    Serial.pushInput("l b\n");
+    console.loop();
+    TEST_ASSERT_FALSE(logger.isBemfLoggingEnabled());
+
+    Serial.pushInput("L B\n");
+    console.loop();
+    TEST_ASSERT_TRUE(logger.isBemfLoggingEnabled());
+}
+
+void test_bemf_logging_accumulation(void) {
+    CvManagerMock cvManager;
+    logger.begin(&cvManager);
+
+    // BEMF logging is ON by default now
+
+    MotorControl motor(cvManager, 10, 11, 2, 3);
+    motor.setup();
+
+    // Set speed to trigger some PWM
+    motor.setSpeed(7, MM2DirectionState_Forward);
+
+    // Mock BEMF readings
+    analog_read_values[2] = 400;
+    analog_read_values[3] = 0;
+
+    Serial.clearLog();
+
+    // Step through 1 second
+    for(int i=0; i<10; i++) {
+        advance_millis(100);
+        motor.setSpeed(7, MM2DirectionState_Forward);
+    }
+
+    bool foundLog = false;
+    for (const auto &line : Serial.logLines) {
+        if (line.find("BEMF: Avg") != std::string::npos) {
+            foundLog = true;
+            // Check if values are present (not zero)
+            TEST_ASSERT_TRUE(line.find("Avg 400") != std::string::npos || line.find("Avg 0") == std::string::npos);
+            break;
+        }
+    }
+    TEST_ASSERT_TRUE(foundLog);
+}

--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -12,6 +12,8 @@
 void test_mm_signal_f0_f1_f2(void);
 void test_cv_programming_6021(void);
 void test_watchdog_shutdown(void);
+void test_bemf_logging_toggle(void);
+void test_bemf_logging_accumulation(void);
 void test_cv_manager_reset_8(void);
 void test_motor_speed_curve(void);
 void test_logging(void);
@@ -814,5 +816,7 @@ int main(int argc, char **argv) {
   RUN_TEST(test_repro_start_backward_kickstart_wrong_dir);
   RUN_TEST(test_repro_bemf_disabled_leftover_adjustment);
   RUN_TEST(test_repro_direction_change_kickstart);
+  RUN_TEST(test_bemf_logging_toggle);
+  RUN_TEST(test_bemf_logging_accumulation);
   return UNITY_END();
 }

--- a/xDuinoRails_MM/Logger.cpp
+++ b/xDuinoRails_MM/Logger.cpp
@@ -5,7 +5,10 @@
 Logger logger;
 
 Logger::Logger()
-    : cvManager(nullptr), cachedEnabled(false), isInitialized(false) {}
+    : cvManager(nullptr),
+      cachedEnabled(false),
+      isInitialized(false),
+      bemfLoggingEnabled(true) {}
 
 void Logger::begin(CvManager *cvManager, unsigned long baudRate) {
   this->cvManager = cvManager;
@@ -22,6 +25,14 @@ void Logger::toggleLogging() {
 }
 
 bool Logger::isLoggingEnabled() { return cachedEnabled; }
+
+void Logger::toggleBemfLogging() {
+  bemfLoggingEnabled = !bemfLoggingEnabled;
+  Serial.print("Serial: BEMF Logging ");
+  Serial.println(bemfLoggingEnabled ? "ON" : "OFF");
+}
+
+bool Logger::isBemfLoggingEnabled() { return bemfLoggingEnabled; }
 
 bool Logger::isEnabled() {
   if (cvManager == nullptr)
@@ -43,6 +54,17 @@ void Logger::println(const char *message) {
 
 void Logger::printf(const char *format, ...) {
   if (isInitialized && cachedEnabled) {
+    char    buf[128];
+    va_list args;
+    va_start(args, format);
+    vsnprintf(buf, sizeof(buf), format, args);
+    va_end(args);
+    Serial.print(buf);
+  }
+}
+
+void Logger::rawPrintf(const char *format, ...) {
+  if (isInitialized) {
     char    buf[128];
     va_list args;
     va_start(args, format);

--- a/xDuinoRails_MM/Logger.h
+++ b/xDuinoRails_MM/Logger.h
@@ -11,14 +11,18 @@ public:
   void print(const char *message);
   void println(const char *message);
   void printf(const char *format, ...);
+  void rawPrintf(const char *format, ...);
   void toggleLogging();
   bool isLoggingEnabled();
+  void toggleBemfLogging();
+  bool isBemfLoggingEnabled();
 
 private:
   CvManager *cvManager;
   bool       isEnabled();
   bool       cachedEnabled;
   bool       isInitialized;
+  bool       bemfLoggingEnabled;
 };
 
 extern Logger logger;

--- a/xDuinoRails_MM/MotorControl.cpp
+++ b/xDuinoRails_MM/MotorControl.cpp
@@ -20,6 +20,13 @@ MotorControl::MotorControl(CvManager &cvManager, int pinA, int pinB, int bemfA,
   previousPwm         = 0;
   bemfErrorSum        = 0;
   lastAdjustment      = 0;
+
+  lastMeasuredBemf = 0;
+  lastMeasuredPwm  = 0;
+  bemfSum          = 0;
+  pwmSum           = 0;
+  sampleCount      = 0;
+  lastLogTime      = 0;
 }
 
 void MotorControl::setup() {
@@ -130,6 +137,9 @@ void MotorControl::update(int pwm, MM2DirectionState dir) {
   targetDirection   = dir;
   unsigned long now = millis();
 
+  int currentBEMF   = -1;
+  int pwmForLogging = 0;
+
   // Bei Stillstand Richtung sofort übernehmen
   if (targetPwm == 0) {
     currDirection = targetDirection;
@@ -155,7 +165,7 @@ void MotorControl::update(int pwm, MM2DirectionState dir) {
     } else {
       bool bemfEnabled = (cvManager.getCv(CV_BEMF_CONFIG) & 0x01);
       if (bemfEnabled && (now - lastBemfMeasure > BEMF_SAMPLE_INT)) {
-        int currentBEMF = readBEMF();
+        currentBEMF     = readBEMF();
         lastBemfMeasure = now;
         if (currentBEMF > BEMF_THRESHOLD) {
           isKickstarting_priv = false;
@@ -163,7 +173,8 @@ void MotorControl::update(int pwm, MM2DirectionState dir) {
         }
       }
       if (isKickstarting_priv) {
-        writeMotorHardware(KICK_PWM, currDirection);
+        pwmForLogging = KICK_PWM;
+        writeMotorHardware(pwmForLogging, currDirection);
       }
     }
   }
@@ -181,7 +192,7 @@ void MotorControl::update(int pwm, MM2DirectionState dir) {
       bool bemfEnabled = (cvManager.getCv(CV_BEMF_CONFIG) & 0x01);
       if (bemfEnabled && targetPwm > 0) {
         if (now - lastBemfMeasure > BEMF_SAMPLE_INT) {
-          int currentBEMF = readBEMF();
+          currentBEMF     = readBEMF();
           lastBemfMeasure = now;
 
           // PI-Regler
@@ -209,9 +220,39 @@ void MotorControl::update(int pwm, MM2DirectionState dir) {
         bemfErrorSum   = 0;
       }
 
-      writeMotorHardware(finalPwm, currDirection);
+      pwmForLogging = finalPwm;
+      writeMotorHardware(pwmForLogging, currDirection);
     }
   }
+
+  // Statistics logging
+  if (logger.isBemfLoggingEnabled()) {
+    if (currentBEMF == -1 && (now - lastBemfMeasure > BEMF_SAMPLE_INT)) {
+      currentBEMF     = readBEMF();
+      lastBemfMeasure = now;
+    }
+
+    if (currentBEMF != -1) {
+      bemfSum += currentBEMF;
+      pwmSum += pwmForLogging;
+      sampleCount++;
+      lastMeasuredBemf = currentBEMF;
+      lastMeasuredPwm  = pwmForLogging;
+    }
+
+    if (now - lastLogTime >= 1000) {
+      if (sampleCount > 0) {
+        logger.rawPrintf("BEMF: Avg %ld, Last %d | PWM: Avg %ld, Last %d\n",
+                         bemfSum / sampleCount, lastMeasuredBemf,
+                         pwmSum / sampleCount, lastMeasuredPwm);
+      }
+      bemfSum     = 0;
+      pwmSum      = 0;
+      sampleCount = 0;
+      lastLogTime = now;
+    }
+  }
+
   previousPwm = targetPwm;
 }
 

--- a/xDuinoRails_MM/MotorControl.h
+++ b/xDuinoRails_MM/MotorControl.h
@@ -35,6 +35,14 @@ private:
   long              bemfErrorSum;
   int               lastAdjustment;
 
+  // BEMF & PWM logging statistics
+  int           lastMeasuredBemf;
+  int           lastMeasuredPwm;
+  long          bemfSum;
+  long          pwmSum;
+  int           sampleCount;
+  unsigned long lastLogTime;
+
   // Motor parameters - will be set based on motorType
   int PWM_FREQ;
   int KICK_PWM;

--- a/xDuinoRails_MM/SerialConsole.cpp
+++ b/xDuinoRails_MM/SerialConsole.cpp
@@ -50,8 +50,12 @@ void SerialConsole::parseCommand(char *line) {
     protocol->setFunctionState(1, val1 > 0);
     logger.printf("Serial: Function 1 set to %d\n", val1 > 0);
   } else if (line[0] == 'L' || line[0] == 'l') {
-    logger.toggleLogging();
-    Serial.print("Serial: Logging ");
-    Serial.println(logger.isLoggingEnabled() ? "ON" : "OFF");
+    if (line[1] == ' ' && (line[2] == 'b' || line[2] == 'B')) {
+      logger.toggleBemfLogging();
+    } else {
+      logger.toggleLogging();
+      Serial.print("Serial: Logging ");
+      Serial.println(logger.isLoggingEnabled() ? "ON" : "OFF");
+    }
   }
 }


### PR DESCRIPTION
This change introduces a new telemetry logging feature that outputs average and last measured BEMF and PWM values every second. The logging is enabled by default and can be toggled via the 'l b' serial command. 

Key changes:
- Logger: Added `bemfLoggingEnabled` flag and `rawPrintf` method.
- SerialConsole: Added handling for the 'l b' toggle command.
- MotorControl: Added fields for statistics (sum, count, last values) and logic to report them every 1000ms.
- Tests: Added `test_bemf_logging.cpp` with unit tests for the new functionality and updated native mocks to support `Serial.printf`.

Fixes #210

---
*PR created automatically by Jules for task [13771144373387142383](https://jules.google.com/task/13771144373387142383) started by @chatelao*