### PR TITLE
Add help command to SerialConsole CLI

### DIFF
--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -26,6 +26,7 @@ void test_motor_pwm_mapping_new_defaults(void);
 void test_debug_leds_heartbeat(void);
 void test_motor_bemf_pi_control(void);
 void test_serial_console_logging_toggle(void);
+void test_serial_console_help(void);
 void test_repro_watchdog_stop_no_kickstart(void);
 void test_repro_start_backward_kickstart_wrong_dir(void);
 void test_repro_bemf_disabled_leftover_adjustment(void);
@@ -726,6 +727,43 @@ void test_serial_console_logging_toggle(void) {
   TEST_ASSERT_EQUAL(1, cvManager.getCv(CV_DEBUG_ENABLE));
 }
 
+void test_serial_console_help(void) {
+  CvManagerMock   cvManager;
+  ProtocolHandler protocol(0);
+  protocol.setAddress(1);
+  SerialConsole console(&cvManager, &protocol);
+
+  Serial.clearLog();
+
+  // Test "h" command for help
+  Serial.pushInput("h\n");
+  console.loop();
+
+  bool foundHeader = false;
+  bool foundCvCmd  = false;
+  for (const auto &line : Serial.logLines) {
+    if (line.find("--- xDuinoRails Serial Console Help ---") != std::string::npos)
+      foundHeader = true;
+    if (line.find("cv <num> <val> : Set CV value") != std::string::npos)
+      foundCvCmd = true;
+  }
+  TEST_ASSERT_TRUE(foundHeader);
+  TEST_ASSERT_TRUE(foundCvCmd);
+
+  Serial.clearLog();
+
+  // Test "?" command for help
+  Serial.pushInput("?\n");
+  console.loop();
+
+  foundHeader = false;
+  for (const auto &line : Serial.logLines) {
+    if (line.find("--- xDuinoRails Serial Console Help ---") != std::string::npos)
+      foundHeader = true;
+  }
+  TEST_ASSERT_TRUE(foundHeader);
+}
+
 void test_cv_programming_6021(void) {
   CvManagerMock   cvManager;
   ProtocolHandler protocol(0);
@@ -812,6 +850,7 @@ int main(int argc, char **argv) {
   RUN_TEST(test_debug_leds_heartbeat);
   RUN_TEST(test_motor_bemf_pi_control);
   RUN_TEST(test_serial_console_logging_toggle);
+  RUN_TEST(test_serial_console_help);
   RUN_TEST(test_repro_watchdog_stop_no_kickstart);
   RUN_TEST(test_repro_start_backward_kickstart_wrong_dir);
   RUN_TEST(test_repro_bemf_disabled_leftover_adjustment);

--- a/xDuinoRails_MM/SerialConsole.cpp
+++ b/xDuinoRails_MM/SerialConsole.cpp
@@ -70,5 +70,23 @@ void SerialConsole::parseCommand(char *line) {
       Serial.print("Serial: Logging ");
       Serial.println(logger.isLoggingEnabled() ? "ON" : "OFF");
     }
+  } else if (strcmp(line, "h") == 0 || strcmp(line, "?") == 0) {
+    printHelp();
   }
+}
+
+void SerialConsole::printHelp() {
+  Serial.println("--- xDuinoRails Serial Console Help ---");
+  Serial.println("cv <num> <val> : Set CV value");
+  Serial.println("cv             : Print all CV values");
+  Serial.println("s <speed>      : Set speed (0-14)");
+  Serial.println("d f            : Set direction forward");
+  Serial.println("d b            : Set direction backward");
+  Serial.println("f <0/1>        : Set Function 1 (0=off, 1=on)");
+  Serial.println("L or l         : Toggle master logging");
+  Serial.println("l p            : Toggle Protocol logging");
+  Serial.println("l w            : Toggle PWM logging");
+  Serial.println("l c            : Toggle CV logging");
+  Serial.println("h or ?         : Show this help message");
+  Serial.println("---------------------------------------");
 }

--- a/xDuinoRails_MM/SerialConsole.h
+++ b/xDuinoRails_MM/SerialConsole.h
@@ -17,6 +17,7 @@ private:
   int              bufferIndex;
 
   void parseCommand(char *line);
+  void printHelp();
 };
 
 #endif // SERIAL_CONSOLE_H


### PR DESCRIPTION
This PR adds a help command ('h' or '?') to the SerialConsole CLI to improve usability. Users can now see a list of all supported commands directly in the terminal. The implementation includes the help text generation logic and unit tests to ensure correct behavior and prevent regressions.

Fixes #218

---
*PR created automatically by Jules for task [15526906010333435625](https://jules.google.com/task/15526906010333435625) started by @chatelao*