### PR TITLE
Implement BEMF and PWM Telemetry Logging

### DIFF
--- a/test/test_native/test_logger_categories.cpp
+++ b/test/test_native/test_logger_categories.cpp
@@ -80,17 +80,33 @@ void test_logger_categories(void) {
   TEST_ASSERT_FALSE(foundCvHidden);
   TEST_ASSERT_TRUE(foundGeneralVisible);
 
+  // 4.5 Disable BEMF
+  Serial.clearLog();
+  Serial.pushInput("l b\n");
+  console.loop();
+
+  logger.printf(LogCategory::BEMF, "BEMF Hidden");
+  logger.printf(LogCategory::General, "General Visible 2");
+
+  bool foundBemfHidden = false;
+  for (const auto& line : Serial.logLines) {
+      if (line.find("BEMF Hidden") != std::string::npos) foundBemfHidden = true;
+  }
+  TEST_ASSERT_FALSE(foundBemfHidden);
+
   // 5. Re-enable all
   Serial.pushInput("l p\n");
   Serial.pushInput("l w\n");
   Serial.pushInput("l c\n");
+  Serial.pushInput("l b\n");
   console.loop();
 
   Serial.clearLog();
   logger.printf(LogCategory::Protocol, "P");
   logger.printf(LogCategory::PWM, "W");
   logger.printf(LogCategory::CV, "C");
-  TEST_ASSERT_EQUAL(3, Serial.logLines.size());
+  logger.printf(LogCategory::BEMF, "B");
+  TEST_ASSERT_EQUAL(4, Serial.logLines.size());
 
   // 6. Master Toggle
   Serial.pushInput("l\n");

--- a/xDuinoRails_MM/Logger.cpp
+++ b/xDuinoRails_MM/Logger.cpp
@@ -6,7 +6,8 @@ Logger logger;
 
 Logger::Logger()
     : cvManager(nullptr), cachedEnabled(false), protocolEnabled(true),
-      pwmEnabled(true), cvEnabled(true), isInitialized(false) {}
+      pwmEnabled(true), cvEnabled(true), bemfEnabled(true),
+      isInitialized(false) {}
 
 void Logger::begin(CvManager *cvManager, unsigned long baudRate) {
   this->cvManager = cvManager;
@@ -33,6 +34,9 @@ void Logger::toggleCategory(LogCategory category) {
   case LogCategory::CV:
     cvEnabled = !cvEnabled;
     break;
+  case LogCategory::BEMF:
+    bemfEnabled = !bemfEnabled;
+    break;
   default:
     break;
   }
@@ -48,6 +52,8 @@ bool Logger::isCategoryEnabled(LogCategory category) {
     return pwmEnabled;
   case LogCategory::CV:
     return cvEnabled;
+  case LogCategory::BEMF:
+    return bemfEnabled;
   default:
     return true;
   }

--- a/xDuinoRails_MM/Logger.h
+++ b/xDuinoRails_MM/Logger.h
@@ -4,7 +4,7 @@
 #include "CvManager.h"
 #include <Arduino.h>
 
-enum class LogCategory { General, Protocol, PWM, CV };
+enum class LogCategory { General, Protocol, PWM, CV, BEMF };
 
 class Logger {
 public:
@@ -27,6 +27,7 @@ private:
   bool       protocolEnabled;
   bool       pwmEnabled;
   bool       cvEnabled;
+  bool       bemfEnabled;
   bool       isInitialized;
 };
 

--- a/xDuinoRails_MM/MotorControl.cpp
+++ b/xDuinoRails_MM/MotorControl.cpp
@@ -20,6 +20,14 @@ MotorControl::MotorControl(CvManager &cvManager, int pinA, int pinB, int bemfA,
   previousPwm         = 0;
   bemfErrorSum        = 0;
   lastAdjustment      = 0;
+
+  lastTelemetryTime = 0;
+  bemfSum           = 0;
+  bemfCount         = 0;
+  lastMeasuredBemf  = 0;
+  pwmSum            = 0;
+  pwmCount          = 0;
+  lastSentPwm       = 0;
 }
 
 void MotorControl::setup() {
@@ -72,6 +80,7 @@ void MotorControl::setup() {
 #endif
 
   writeMotorHardware(0, MM2DirectionState_Forward);
+  lastTelemetryTime = millis();
 }
 
 void MotorControl::setSpeed(int step, MM2DirectionState dir) {
@@ -159,6 +168,11 @@ void MotorControl::update(int pwm, MM2DirectionState dir) {
       if (bemfEnabled && (now - lastBemfMeasure > BEMF_SAMPLE_INT)) {
         int currentBEMF = readBEMF();
         lastBemfMeasure = now;
+
+        lastMeasuredBemf = currentBEMF;
+        bemfSum += currentBEMF;
+        bemfCount++;
+
         if (currentBEMF > BEMF_THRESHOLD) {
           isKickstarting_priv = false;
           logger.println("Motor: Kickstart ended (BEMF)", LogCategory::PWM);
@@ -185,6 +199,11 @@ void MotorControl::update(int pwm, MM2DirectionState dir) {
         if (now - lastBemfMeasure > BEMF_SAMPLE_INT) {
           int currentBEMF = readBEMF();
           lastBemfMeasure = now;
+
+          lastMeasuredBemf = currentBEMF;
+          bemfSum += currentBEMF;
+          bemfCount++;
+
 
           // PI-Regler
           // Ziel-BEMF: Wir nehmen an, dass BEMF proportional zu PWM ist.
@@ -215,6 +234,40 @@ void MotorControl::update(int pwm, MM2DirectionState dir) {
     }
   }
   previousPwm = targetPwm;
+
+  // Track PWM for telemetry
+  int currentAppliedPwm = 0;
+  if (isKickstarting_priv) {
+    currentAppliedPwm = KICK_PWM;
+  } else if (currDirection != targetDirection) {
+    currentAppliedPwm = 0;
+  } else {
+    currentAppliedPwm = targetPwm + lastAdjustment;
+  }
+
+  if (currentAppliedPwm > PWM_RANGE)
+    currentAppliedPwm = PWM_RANGE;
+  if (currentAppliedPwm < 0)
+    currentAppliedPwm = 0;
+
+  lastSentPwm = currentAppliedPwm;
+  pwmSum += currentAppliedPwm;
+  pwmCount++;
+
+  if (now - lastTelemetryTime >= 1000) {
+    int avgBemf = (bemfCount > 0) ? (int)(bemfSum / bemfCount) : 0;
+    int avgPwm  = (pwmCount > 0) ? (int)(pwmSum / pwmCount) : 0;
+
+    logger.printf(LogCategory::BEMF,
+                  "BEMF: avg=%d, last=%d | PWM: avg=%d, last=%d\n", avgBemf,
+                  lastMeasuredBemf, avgPwm, lastSentPwm);
+
+    bemfSum           = 0;
+    bemfCount         = 0;
+    pwmSum            = 0;
+    pwmCount          = 0;
+    lastTelemetryTime = now;
+  }
 }
 
 void MotorControl::stop() { update(0, currDirection); }

--- a/xDuinoRails_MM/MotorControl.h
+++ b/xDuinoRails_MM/MotorControl.h
@@ -35,6 +35,15 @@ private:
   long              bemfErrorSum;
   int               lastAdjustment;
 
+  // Telemetry
+  unsigned long lastTelemetryTime;
+  long          bemfSum;
+  int           bemfCount;
+  int           lastMeasuredBemf;
+  long          pwmSum;
+  int           pwmCount;
+  int           lastSentPwm;
+
   // Motor parameters - will be set based on motorType
   int PWM_FREQ;
   int KICK_PWM;

--- a/xDuinoRails_MM/SerialConsole.cpp
+++ b/xDuinoRails_MM/SerialConsole.cpp
@@ -64,6 +64,10 @@ void SerialConsole::parseCommand(char *line) {
         logger.toggleCategory(LogCategory::CV);
         Serial.print("Serial: CV Logging ");
         Serial.println(logger.isCategoryEnabled(LogCategory::CV) ? "ON" : "OFF");
+      } else if (sub == 'b') {
+        logger.toggleCategory(LogCategory::BEMF);
+        Serial.print("Serial: BEMF Logging ");
+        Serial.println(logger.isCategoryEnabled(LogCategory::BEMF) ? "ON" : "OFF");
       }
     } else {
       logger.toggleLogging();


### PR DESCRIPTION
This change implements a requested feature to log motor telemetry (BEMF and PWM) every second.
A new logging category `LogCategory::BEMF` was introduced, which can be toggled via the Serial console using the `l b` command.
The `MotorControl` class now maintains accumulators for BEMF and PWM values to calculate averages over a 1000ms window.
The "last measured" values are also captured.
Following code review, the PWM tracking was moved to the main `update` loop to ensure accurate time-weighted averages even when the motor setpoint is constant.
Native tests were updated to verify the new CLI command and the toggling of the BEMF logging category.

Fixes #217

---
*PR created automatically by Jules for task [16259203805583172444](https://jules.google.com/task/16259203805583172444) started by @chatelao*