### PR TITLE
Fix Motor Stall and Optimize PWM Writes

### DIFF
--- a/test/test_native/test_logger_categories.cpp
+++ b/test/test_native/test_logger_categories.cpp
@@ -15,7 +15,7 @@ void test_logger_categories(void) {
   ProtocolHandler protocol(0);
   protocol.setAddress(1);
 
-  MotorControl motor(cvManager, 10, 11, 2, 3);
+  MotorControl motor(cvManager, 10, 11, 2, 3, 12);
   motor.setup();
 
   SerialConsole console(&cvManager, &protocol);

--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -31,6 +31,8 @@ void test_repro_watchdog_stop_no_kickstart(void);
 void test_repro_start_backward_kickstart_wrong_dir(void);
 void test_repro_bemf_disabled_leftover_adjustment(void);
 void test_repro_direction_change_kickstart(void);
+void test_repro_kickstart_only(void);
+void test_repro_kickstart_only_with_vstart_zero(void);
 
 // Mock implementation for RP2040 reboot
 bool   reboot_called = false;
@@ -122,7 +124,7 @@ void test_motor_speed_control(void) {
   cvManager.setCv(CV_START_VOLTAGE, 10);
   cvManager.setCv(CV_MOTOR_TYPE, 0);
   cvManager.setCv(CV_MAXIMUM_SPEED, 255);
-  MotorControl motor(cvManager, 10, 11, 2, 3);
+  MotorControl motor(cvManager, 10, 11, 2, 3, 12);
   motor.setup();
 
   // Test: Geschwindigkeit 0
@@ -169,7 +171,7 @@ void test_motor_speed_control(void) {
 // Testet das Standardverhalten der Lichtsteuerung.
 void test_lights_control_default_behavior(void) {
   CvManagerMock cvManager;
-  LightsControl lights(cvManager, 0, 1);
+  LightsControl lights(cvManager, 0, 1, 13);
   // TODO: Behauptungen hinzufügen, um das Standard-Lichtverhalten zu überprüfen
 }
 
@@ -226,7 +228,7 @@ void test_watchdog_shutdown(void) {
   protocol.setAddress(1);
   protocol.setSignalTimeout(cvManager.getCv(CV_WATCHDOG_TIMEOUT) * 100);
 
-  MotorControl motor(cvManager, 10, 11, 2, 3);
+  MotorControl motor(cvManager, 10, 11, 2, 3, 12);
   motor.setup();
 
   // 1. Normaler Betrieb: Geschwindigkeit auf 14 setzen
@@ -313,7 +315,7 @@ void test_pwm_freq_logging(void) {
   cvManager.setCv(CV_MOTOR_TYPE, 0);
   Serial.clearLog();
   {
-    MotorControl motor(cvManager, 10, 11, 2, 3);
+    MotorControl motor(cvManager, 10, 11, 2, 3, 12);
     motor.setup();
     bool found = false;
     for (const auto &line : Serial.logLines) {
@@ -330,7 +332,7 @@ void test_pwm_freq_logging(void) {
   cvManager.setCv(CV_MOTOR_TYPE, 1);
   Serial.clearLog();
   {
-    MotorControl motor(cvManager, 10, 11, 2, 3);
+    MotorControl motor(cvManager, 10, 11, 2, 3, 12);
     motor.setup();
     bool found = false;
     for (const auto &line : Serial.logLines) {
@@ -347,7 +349,7 @@ void test_pwm_freq_logging(void) {
   cvManager.setCv(CV_MOTOR_TYPE, 2);
   Serial.clearLog();
   {
-    MotorControl motor(cvManager, 10, 11, 2, 3);
+    MotorControl motor(cvManager, 10, 11, 2, 3, 12);
     motor.setup();
     bool found = false;
     for (const auto &line : Serial.logLines) {
@@ -429,7 +431,7 @@ void test_logging(void) {
   Serial.clearLog();
 
   // Test Motor kickstart logging
-  MotorControl motor(cvManager, 10, 11, 2, 3);
+  MotorControl motor(cvManager, 10, 11, 2, 3, 12);
   motor.setup();
   motor.setSpeed(1, MM2DirectionState_Forward);
 
@@ -580,7 +582,7 @@ void test_motor_kickstart_bemf_disabled(void) {
   // BEMF is disabled by default, but we set it explicitly here too
   cvManager.setCv(CV_BEMF_CONFIG, 0);
 
-  MotorControl motor(cvManager, 10, 11, 2, 3);
+  MotorControl motor(cvManager, 10, 11, 2, 3, 12);
   motor.setup();
 
   Serial.clearLog();
@@ -630,7 +632,7 @@ void test_motor_kickstart_bemf_enabled(void) {
   // Enable BEMF
   cvManager.setCv(CV_BEMF_CONFIG, 1);
 
-  MotorControl motor(cvManager, 10, 11, 2, 3);
+  MotorControl motor(cvManager, 10, 11, 2, 3, 12);
   motor.setup();
 
   Serial.clearLog();
@@ -666,7 +668,7 @@ void test_motor_speed_curve(void) {
   cvManager.setCv(CV_START_VOLTAGE, 50);
   cvManager.setCv(CV_MAXIMUM_SPEED, 200);
   cvManager.setCv(CV_MEDIUM_SPEED, 0);
-  MotorControl motor1(cvManager, 10, 11, 2, 3);
+  MotorControl motor1(cvManager, 10, 11, 2, 3, 12);
   motor1.setup();
 
   motor1.setSpeed(1, MM2DirectionState_Forward);
@@ -866,5 +868,7 @@ int main(int argc, char **argv) {
   RUN_TEST(test_repro_start_backward_kickstart_wrong_dir);
   RUN_TEST(test_repro_bemf_disabled_leftover_adjustment);
   RUN_TEST(test_repro_direction_change_kickstart);
+  RUN_TEST(test_repro_kickstart_only);
+  RUN_TEST(test_repro_kickstart_only_with_vstart_zero);
   return UNITY_END();
 }

--- a/test/test_native/test_motor_analysis.cpp
+++ b/test/test_native/test_motor_analysis.cpp
@@ -18,7 +18,7 @@ void test_motor_pwm_mapping_detailed(void) {
   cvManager.setCv(CV_MOTOR_TYPE, 0);
   cvManager.setCv(CV_BEMF_CONFIG, 0); // Disable BEMF
 
-  MotorControl motor(cvManager, 10, 11, 2, 3);
+  MotorControl motor(cvManager, 10, 11, 2, 3, 12);
   motor.setup();
 
   // Helper to get PWM after kickstart
@@ -58,7 +58,7 @@ void test_motor_pwm_mapping_new_defaults(void) {
   cvManager.setCv(CV_MOTOR_TYPE, 0);
   cvManager.setCv(CV_BEMF_CONFIG, 0); // Disable BEMF
 
-  MotorControl motor(cvManager, 10, 11, 2, 3);
+  MotorControl motor(cvManager, 10, 11, 2, 3, 12);
   motor.setup();
 
   // Helper to get PWM after kickstart
@@ -96,7 +96,7 @@ void test_motor_bemf_pi_control(void) {
   cvManager.setCv(CV_BEMF_I, 64);         // I=64 -> factor 1
   cvManager.setCv(CV_MOTOR_TYPE, 0);
 
-  MotorControl motor(cvManager, 10, 11, 2, 3);
+  MotorControl motor(cvManager, 10, 11, 2, 3, 12);
   motor.setup();
 
   // Set speed to step 7 (targetPwm = 531)

--- a/test/test_native/test_motor_state.cpp
+++ b/test/test_native/test_motor_state.cpp
@@ -13,7 +13,7 @@ void test_repro_watchdog_stop_no_kickstart(void) {
   cvManager.setCv(CV_START_VOLTAGE, 10);
   cvManager.setCv(CV_MOTOR_TYPE, 0);
 
-  MotorControl motor(cvManager, 10, 11, 2, 3);
+  MotorControl motor(cvManager, 10, 11, 2, 3, 12);
   motor.setup();
 
   // 1. Start moving
@@ -37,7 +37,7 @@ void test_repro_start_backward_kickstart_wrong_dir(void) {
   CvManagerMock cvManager;
   cvManager.setCv(CV_MOTOR_TYPE, 0); // KICK_PWM = 800
 
-  MotorControl motor(cvManager, 10, 11, 2, 3);
+  MotorControl motor(cvManager, 10, 11, 2, 3, 12);
   motor.setup();
 
   // Start moving Backward from standstill
@@ -59,7 +59,7 @@ void test_repro_bemf_disabled_leftover_adjustment(void) {
   cvManager.setCv(CV_BEMF_I, 0);
   cvManager.setCv(CV_MOTOR_TYPE, 0);
 
-  MotorControl motor(cvManager, 10, 11, 2, 3);
+  MotorControl motor(cvManager, 10, 11, 2, 3, 12);
   motor.setup();
 
   // Set speed to step 7 (targetPwm = 531)
@@ -94,7 +94,7 @@ void test_repro_direction_change_kickstart(void) {
   cvManager.setCv(CV_START_VOLTAGE, 10);
   cvManager.setCv(CV_MOTOR_TYPE, 0);
 
-  MotorControl motor(cvManager, 10, 11, 2, 3);
+  MotorControl motor(cvManager, 10, 11, 2, 3, 12);
   motor.setup();
 
   // Start moving Forward

--- a/test/test_native/test_repro_issue.cpp
+++ b/test/test_native/test_repro_issue.cpp
@@ -1,0 +1,62 @@
+#include "CvManagerMock.h"
+#include "MotorControl.h"
+#include "RP2040.h"
+#include <unity.h>
+#include <map>
+
+extern std::map<uint8_t, int> analog_write_values;
+extern void advance_millis(unsigned long ms);
+
+void test_repro_kickstart_only(void) {
+  CvManagerMock cvManager;
+  cvManager.setCv(CV_BEMF_CONFIG, 0); // Disable BEMF
+  cvManager.setCv(CV_START_VOLTAGE, 10);
+  cvManager.setCv(CV_MEDIUM_SPEED, 0);
+  cvManager.setCv(CV_MAXIMUM_SPEED, 255);
+  cvManager.setCv(CV_MOTOR_TYPE, 0); // Standard DC
+
+  MotorControl motor(cvManager, 10, 11, 2, 3, 12);
+  motor.setup();
+
+  // 1. Trigger kickstart
+  motor.setSpeed(7, MM2DirectionState_Forward);
+  TEST_ASSERT_TRUE(motor.isKickstarting());
+  TEST_ASSERT_EQUAL(800, analog_write_values[10]);
+
+  // 2. Advance time to end kickstart by timeout
+  advance_millis(150);
+
+  // 3. Call update again (as loop() would do)
+  motor.setSpeed(7, MM2DirectionState_Forward);
+
+  TEST_ASSERT_FALSE(motor.isKickstarting());
+  // Expect PWM for step 7, which is 531
+  TEST_ASSERT_EQUAL(531, analog_write_values[10]);
+}
+
+void test_repro_kickstart_only_with_vstart_zero(void) {
+  CvManagerMock cvManager;
+  cvManager.setCv(CV_BEMF_CONFIG, 0); // Disable BEMF
+  cvManager.setCv(CV_START_VOLTAGE, 0);
+  cvManager.setCv(CV_MEDIUM_SPEED, 0);
+  cvManager.setCv(CV_MAXIMUM_SPEED, 0);
+  cvManager.setCv(CV_MOTOR_TYPE, 0); // Standard DC
+
+  MotorControl motor(cvManager, 10, 11, 2, 3, 12);
+  motor.setup();
+
+  // 1. Trigger kickstart
+  motor.setSpeed(7, MM2DirectionState_Forward);
+  TEST_ASSERT_TRUE(motor.isKickstarting());
+  TEST_ASSERT_EQUAL(800, analog_write_values[10]);
+
+  // 2. Advance time to end kickstart by timeout
+  advance_millis(150);
+
+  // 3. Call update again (as loop() would do)
+  motor.setSpeed(7, MM2DirectionState_Forward);
+
+  TEST_ASSERT_FALSE(motor.isKickstarting());
+  // vStart=1, vHigh=1023 -> vMid=512. map(7, 1, 7, 1, 512) = 512
+  TEST_ASSERT_EQUAL(512, analog_write_values[10]);
+}

--- a/xDuinoRails_MM/LightsControl.cpp
+++ b/xDuinoRails_MM/LightsControl.cpp
@@ -1,14 +1,23 @@
 #include "LightsControl.h"
 
-LightsControl::LightsControl(CvManager &cvManager, int f0fPin, int f0bPin)
+LightsControl::LightsControl(CvManager &cvManager, int f0fPin, int f0bPin,
+                             int shutPin)
     : cvManager(cvManager) {
-  f0fPin_priv = f0fPin;
-  f0bPin_priv = f0bPin;
+  f0fPin_priv   = f0fPin;
+  f0bPin_priv   = f0bPin;
+  shutPin_priv  = shutPin;
+  lastDirection = MM2DirectionState_Unavailable;
+  lastF0f       = false;
+  lastF0r       = false;
 }
 
 void LightsControl::setup() {
   pinMode(f0fPin_priv, OUTPUT);
   pinMode(f0bPin_priv, OUTPUT);
+  if (shutPin_priv != -1) {
+    pinMode(shutPin_priv, OUTPUT);
+    digitalWrite(shutPin_priv, LOW); // Active high shutdown -> LOW = enabled
+  }
 }
 
 void LightsControl::update(MM2DirectionState direction, bool f0) {
@@ -18,6 +27,10 @@ void LightsControl::update(MM2DirectionState direction, bool f0) {
   bool f0f = (f0fCv & 0x01) && f0;
   bool f0r = (f0rCv & 0x02) && f0;
 
+  if (direction == lastDirection && f0f == lastF0f && f0r == lastF0r) {
+    return;
+  }
+
   if (direction == MM2DirectionState_Forward) {
     digitalWrite(f0fPin_priv, f0f ? HIGH : LOW);
     digitalWrite(f0bPin_priv, LOW);
@@ -25,4 +38,8 @@ void LightsControl::update(MM2DirectionState direction, bool f0) {
     digitalWrite(f0fPin_priv, LOW);
     digitalWrite(f0bPin_priv, f0r ? HIGH : LOW);
   }
+
+  lastDirection = direction;
+  lastF0f       = f0f;
+  lastF0r       = f0r;
 }

--- a/xDuinoRails_MM/LightsControl.h
+++ b/xDuinoRails_MM/LightsControl.h
@@ -7,7 +7,7 @@
 
 class LightsControl {
 public:
-  LightsControl(CvManager &cvManager, int f0fPin, int f0bPin);
+  LightsControl(CvManager &cvManager, int f0fPin, int f0bPin, int shutPin);
   void setup();
   void update(MM2DirectionState direction, bool f0);
 
@@ -15,6 +15,11 @@ private:
   CvManager &cvManager;
   int        f0fPin_priv;
   int        f0bPin_priv;
+  int        shutPin_priv;
+
+  MM2DirectionState lastDirection;
+  bool              lastF0f;
+  bool              lastF0r;
 };
 
 #endif // LIGHTS_CONTROL_H

--- a/xDuinoRails_MM/MotorControl.cpp
+++ b/xDuinoRails_MM/MotorControl.cpp
@@ -4,12 +4,13 @@
 const int PWM_RANGE = 1023;
 
 MotorControl::MotorControl(CvManager &cvManager, int pinA, int pinB, int bemfA,
-                           int bemfB)
+                           int bemfB, int shutPin)
     : cvManager(cvManager) {
   pinA_priv           = pinA;
   pinB_priv           = pinB;
   bemfA_priv          = bemfA;
   bemfB_priv          = bemfB;
+  shutPin_priv        = shutPin;
   targetPwm           = 0;
   currDirection       = MM2DirectionState_Forward;
   targetDirection     = MM2DirectionState_Forward;
@@ -20,6 +21,9 @@ MotorControl::MotorControl(CvManager &cvManager, int pinA, int pinB, int bemfA,
   previousPwm         = 0;
   bemfErrorSum        = 0;
   lastAdjustment      = 0;
+
+  lastWrittenPwm      = -1;
+  lastWrittenDir      = MM2DirectionState_Unavailable;
 
   lastTelemetryTime = 0;
   bemfSum           = 0;
@@ -35,6 +39,11 @@ void MotorControl::setup() {
   pinMode(pinB_priv, OUTPUT);
   pinMode(bemfA_priv, INPUT);
   pinMode(bemfB_priv, INPUT);
+
+  if (shutPin_priv != -1) {
+    pinMode(shutPin_priv, OUTPUT);
+    digitalWrite(shutPin_priv, LOW); // Active high shutdown -> LOW = enabled
+  }
 
   int         motorType = cvManager.getCv(CV_MOTOR_TYPE);
   const char *typeName  = "Standard DC";
@@ -282,13 +291,25 @@ void MotorControl::writeMotorHardware(int pwm, MM2DirectionState dir) {
   if (pwm < 0)
     pwm = 0;
 
+  if (pwm == lastWrittenPwm && dir == lastWrittenDir)
+    return;
+
   if (dir == MM2DirectionState_Forward) {
     digitalWrite(pinB_priv, LOW);
     analogWrite(pinA_priv, pwm);
+    if (lastWrittenDir == MM2DirectionState_Backward) {
+      analogWrite(pinB_priv, 0); // Ensure other pin is off
+    }
   } else {
     digitalWrite(pinA_priv, LOW);
     analogWrite(pinB_priv, pwm);
+    if (lastWrittenDir == MM2DirectionState_Forward) {
+      analogWrite(pinA_priv, 0); // Ensure other pin is off
+    }
   }
+
+  lastWrittenPwm = pwm;
+  lastWrittenDir = dir;
 }
 
 int MotorControl::readBEMF() {
@@ -297,5 +318,9 @@ int MotorControl::readBEMF() {
   delayMicroseconds(500);
   int valA = analogRead(bemfA_priv);
   int valB = analogRead(bemfB_priv);
+
+  // Since we touched the pins, invalidate the write cache
+  lastWrittenPwm = -1;
+
   return (valA > valB) ? (valA - valB) : (valB - valA);
 }

--- a/xDuinoRails_MM/MotorControl.h
+++ b/xDuinoRails_MM/MotorControl.h
@@ -7,7 +7,8 @@
 
 class MotorControl {
 public:
-  MotorControl(CvManager &cvManager, int pinA, int pinB, int bemfA, int bemfB);
+  MotorControl(CvManager &cvManager, int pinA, int pinB, int bemfA, int bemfB,
+               int shutPin);
   void              setup();
   void              setSpeed(int step, MM2DirectionState targetDir);
   void              stop();
@@ -24,6 +25,7 @@ private:
   int               pinB_priv;
   int               bemfA_priv;
   int               bemfB_priv;
+  int               shutPin_priv;
   int               targetPwm;
   MM2DirectionState currDirection;
   MM2DirectionState targetDirection;
@@ -34,6 +36,9 @@ private:
   int               previousPwm;
   long              bemfErrorSum;
   int               lastAdjustment;
+
+  int               lastWrittenPwm;
+  MM2DirectionState lastWrittenDir;
 
   // Telemetry
   unsigned long lastTelemetryTime;

--- a/xDuinoRails_MM/xDuinoRails_MM.ino
+++ b/xDuinoRails_MM/xDuinoRails_MM.ino
@@ -75,8 +75,9 @@ const int NUMPIXELS = 1;
 CvManager cvManager;
 
 ProtocolHandler protocol(DCC_MM_SIGNAL);
-MotorControl motor(cvManager, MOTOR_PIN_A, MOTOR_PIN_B, BEMF_PIN_A, BEMF_PIN_B);
-LightsControl lights(cvManager, LED_F0f, LED_F0b);
+MotorControl motor(cvManager, MOTOR_PIN_A, MOTOR_PIN_B, BEMF_PIN_A, BEMF_PIN_B,
+                   MOTOR_SHUT_PIN);
+LightsControl lights(cvManager, LED_F0f, LED_F0b, FUNC_SHUT_PIN);
 CvProgrammer  cvProgrammer(&cvManager, &protocol);
 SerialConsole serialConsole(&cvManager, &protocol);
 


### PR DESCRIPTION
This change fixes a bug where the motor would only perform the initial kickstart pulse and then stall when BEMF was disabled (CV 49 = 0). The primary causes were uninitialized shutdown pins and excessive PWM updates that reset the hardware timers on the RP2040.

Key improvements:
1. **Shutdown Pin Support:** The firmware now correctly initializes and enables the motor and function drivers via their respective shutdown pins (D2/D3).
2. **PWM Write Optimization:** A hardware write cache in `MotorControl` and `LightsControl` ensures that `analogWrite` and `digitalWrite` are only called when the state actually changes. This prevents PWM cycle resets caused by high-frequency updates in the main loop when the BEMF sensing delay is absent.
3. **Cache Invalidation:** `MotorControl::readBEMF()` now invalidates the write cache after manually pulling pins LOW for sensing, ensuring the motor resumes at the correct target PWM.
4. **Test Coverage:** Added new native tests in `test/test_native/test_repro_issue.cpp` to verify logic behavior when BEMF is disabled.

Fixes #222

---
*PR created automatically by Jules for task [13360643543765972152](https://jules.google.com/task/13360643543765972152) started by @chatelao*