### PR TITLE
Fix motor stalling after kickstart with BEMF disabled

### DIFF
--- a/test/test_native/test_cv49_verification.cpp
+++ b/test/test_native/test_cv49_verification.cpp
@@ -1,0 +1,45 @@
+#include "CvManagerMock.h"
+#include "MotorControl.h"
+#include "RP2040.h"
+#include <unity.h>
+#include <map>
+
+extern std::map<uint8_t, int> analog_write_values;
+extern void advance_millis(unsigned long ms);
+
+void test_cv49_zero_only_kickstart_works(void) {
+  CvManagerMock cvManager;
+
+  // Factory reset defaults
+  cvManager.setCv(CV_START_VOLTAGE, 10); // vStart = 40
+  cvManager.setCv(CV_MAXIMUM_SPEED, 0);  // vHigh = 1023
+  cvManager.setCv(CV_MEDIUM_SPEED, 0);   // vMid = 531
+  cvManager.setCv(CV_MOTOR_TYPE, 0);
+
+  // Disable BEMF
+  cvManager.setCv(CV_BEMF_CONFIG, 0);
+
+  MotorControl motor(cvManager, 10, 11, 2, 3, 12);
+  motor.setup();
+
+  // 1. Start moving
+  motor.setSpeed(7, MM2DirectionState_Forward);
+
+  // Should be kickstarting
+  TEST_ASSERT_TRUE(motor.isKickstarting());
+  TEST_ASSERT_EQUAL(800, analog_write_values[10]);
+
+  // 2. Loop during kickstart
+  advance_millis(50);
+  motor.setSpeed(7, MM2DirectionState_Forward);
+  TEST_ASSERT_TRUE(motor.isKickstarting());
+  TEST_ASSERT_EQUAL(800, analog_write_values[10]);
+
+  // 3. Kickstart ends via timeout
+  advance_millis(100); // total 150ms > 100ms
+  motor.setSpeed(7, MM2DirectionState_Forward);
+
+  TEST_ASSERT_FALSE(motor.isKickstarting());
+  // HERE IS THE CRITICAL PART: PWM should now be 531
+  TEST_ASSERT_EQUAL(531, analog_write_values[10]);
+}

--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -33,6 +33,7 @@ void test_repro_bemf_disabled_leftover_adjustment(void);
 void test_repro_direction_change_kickstart(void);
 void test_repro_kickstart_only(void);
 void test_repro_kickstart_only_with_vstart_zero(void);
+void test_cv49_zero_only_kickstart_works(void);
 
 // Mock implementation for RP2040 reboot
 bool   reboot_called = false;
@@ -870,5 +871,6 @@ int main(int argc, char **argv) {
   RUN_TEST(test_repro_direction_change_kickstart);
   RUN_TEST(test_repro_kickstart_only);
   RUN_TEST(test_repro_kickstart_only_with_vstart_zero);
+  RUN_TEST(test_cv49_zero_only_kickstart_works);
   return UNITY_END();
 }

--- a/xDuinoRails_MM/MotorControl.cpp
+++ b/xDuinoRails_MM/MotorControl.cpp
@@ -171,7 +171,9 @@ void MotorControl::update(int pwm, MM2DirectionState dir) {
   if (isKickstarting_priv) {
     if (now - kickstartBegin >= KICK_MAX_TIME) {
       isKickstarting_priv = false;
-      logger.println("Motor: Kickstart ended (timeout)", LogCategory::PWM);
+      lastWrittenPwm      = -1; // Force hardware update for transition
+      logger.printf(LogCategory::PWM,
+                    "Motor: Kickstart ended (timeout) -> PWM %d\n", targetPwm);
     } else {
       bool bemfEnabled = (cvManager.getCv(CV_BEMF_CONFIG) & 0x01);
       if (bemfEnabled && (now - lastBemfMeasure > BEMF_SAMPLE_INT)) {
@@ -184,7 +186,9 @@ void MotorControl::update(int pwm, MM2DirectionState dir) {
 
         if (currentBEMF > BEMF_THRESHOLD) {
           isKickstarting_priv = false;
-          logger.println("Motor: Kickstart ended (BEMF)", LogCategory::PWM);
+          lastWrittenPwm      = -1; // Force hardware update for transition
+          logger.printf(LogCategory::PWM,
+                        "Motor: Kickstart ended (BEMF) -> PWM %d\n", targetPwm);
         }
       }
       if (isKickstarting_priv) {


### PR DESCRIPTION
Ensured robust transition from kickstart to target PWM when BEMF is disabled by invalidating the hardware cache and forcing a refresh. Verified with new native tests.

Fixes #229

---
*PR created automatically by Jules for task [13210136554250034130](https://jules.google.com/task/13210136554250034130) started by @chatelao*