### PR TITLE
Fix motor stall when CV 49 = 0 (BEMF disabled)

### DIFF
--- a/test/test_native/test_cv49_verification.cpp
+++ b/test/test_native/test_cv49_verification.cpp
@@ -1,0 +1,112 @@
+#include "CvManagerMock.h"
+#include "MotorControl.h"
+#include "RP2040.h"
+#include <unity.h>
+
+extern std::map<uint8_t, int> analog_write_values;
+extern void advance_millis(unsigned long ms);
+
+void test_cv49_zero_only_kickstart_works(void) {
+  CvManagerMock cvManager;
+  // Factory reset defaults (simulated)
+  cvManager.setCv(CV_START_VOLTAGE, 1);
+  cvManager.setCv(CV_MEDIUM_SPEED, 127);
+  cvManager.setCv(CV_MAXIMUM_SPEED, 255);
+  cvManager.setCv(CV_MOTOR_TYPE, 0); // Standard DC
+  cvManager.setCv(CV_BEMF_CONFIG, 0); // Disable BEMF as per issue report
+
+  MotorControl motor(cvManager, 10, 11, 2, 3);
+  motor.setup();
+
+  // Reset mocks
+  analog_write_values.clear();
+
+  // Set speed to step 7 (targetPwm = 509 approx. with CV 2=1, 5=255, 6=127)
+  // Step 1: PWM 4, Step 7: PWM 509, Step 14: PWM 1023
+  motor.setSpeed(7, MM2DirectionState_Forward);
+
+  // Should be kickstarting
+  TEST_ASSERT_TRUE(motor.isKickstarting());
+  TEST_ASSERT_EQUAL(800, analog_write_values[10]); // KICK_PWM for Standard DC
+
+  // Advance time past kickstart timeout (100ms)
+  advance_millis(150);
+
+  // Update motor speed again (to trigger the transition check)
+  motor.setSpeed(7, MM2DirectionState_Forward);
+
+  // Kickstart should be over
+  TEST_ASSERT_FALSE(motor.isKickstarting());
+
+  // Hardware should now be driven with targetPwm
+  // vStart = map(1, 0, 255, 0, 1023) = 4
+  // vMid = map(127, 0, 255, 0, 1023) = 509
+  // Step 7 -> 509
+  TEST_ASSERT_EQUAL(509, analog_write_values[10]);
+}
+
+void test_cv49_zero_detailed_simulation(void) {
+  CvManagerMock cvManager;
+  cvManager.setCv(CV_START_VOLTAGE, 10);
+  cvManager.setCv(CV_MEDIUM_SPEED, 0);
+  cvManager.setCv(CV_MAXIMUM_SPEED, 0);
+  cvManager.setCv(CV_MOTOR_TYPE, 0); // Standard DC
+  cvManager.setCv(CV_BEMF_CONFIG, 0); // Disable BEMF
+
+  MotorControl motor(cvManager, 10, 11, 2, 3);
+  motor.setup();
+
+  // Reset mocks
+  analog_write_values.clear();
+
+  // 1. Initial call - Step 7 (targetPwm = 531)
+  motor.setSpeed(7, MM2DirectionState_Forward);
+  TEST_ASSERT_TRUE(motor.isKickstarting());
+  TEST_ASSERT_EQUAL(800, analog_write_values[10]);
+
+  // 2. Subsequent call within kickstart time
+  advance_millis(50);
+  motor.setSpeed(7, MM2DirectionState_Forward);
+  TEST_ASSERT_TRUE(motor.isKickstarting());
+  TEST_ASSERT_EQUAL(800, analog_write_values[10]);
+
+  // 3. Call that triggers timeout
+  advance_millis(60); // Total 110ms > 100ms
+  motor.setSpeed(7, MM2DirectionState_Forward);
+
+  TEST_ASSERT_FALSE(motor.isKickstarting());
+  // It should now have transitioned to targetPwm (531)
+  TEST_ASSERT_EQUAL(531, analog_write_values[10]);
+
+  // 4. Subsequent calls after kickstart
+  advance_millis(20);
+  motor.setSpeed(7, MM2DirectionState_Forward);
+  TEST_ASSERT_FALSE(motor.isKickstarting());
+  TEST_ASSERT_EQUAL(531, analog_write_values[10]);
+}
+
+void test_cv49_zero_with_stop_start(void) {
+  CvManagerMock cvManager;
+  cvManager.setCv(CV_START_VOLTAGE, 10);
+  cvManager.setCv(CV_MEDIUM_SPEED, 0);
+  cvManager.setCv(CV_MAXIMUM_SPEED, 0);
+  cvManager.setCv(CV_BEMF_CONFIG, 0);
+  MotorControl motor(cvManager, 10, 11, 2, 3);
+  motor.setup();
+
+  // Start
+  motor.setSpeed(7, MM2DirectionState_Forward);
+  advance_millis(150);
+  motor.setSpeed(7, MM2DirectionState_Forward);
+  TEST_ASSERT_EQUAL(531, analog_write_values[10]);
+
+  // Stop
+  motor.setSpeed(0, MM2DirectionState_Forward);
+  TEST_ASSERT_EQUAL(0, analog_write_values[10]);
+  TEST_ASSERT_FALSE(motor.isKickstarting());
+
+  // Start again
+  motor.setSpeed(7, MM2DirectionState_Forward);
+  TEST_ASSERT_TRUE(motor.isKickstarting());
+  TEST_ASSERT_EQUAL(800, analog_write_values[10]);
+}

--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -31,6 +31,9 @@ void test_repro_watchdog_stop_no_kickstart(void);
 void test_repro_start_backward_kickstart_wrong_dir(void);
 void test_repro_bemf_disabled_leftover_adjustment(void);
 void test_repro_direction_change_kickstart(void);
+void test_cv49_zero_only_kickstart_works(void);
+void test_cv49_zero_detailed_simulation(void);
+void test_cv49_zero_with_stop_start(void);
 
 // Mock implementation for RP2040 reboot
 bool   reboot_called = false;
@@ -866,5 +869,8 @@ int main(int argc, char **argv) {
   RUN_TEST(test_repro_start_backward_kickstart_wrong_dir);
   RUN_TEST(test_repro_bemf_disabled_leftover_adjustment);
   RUN_TEST(test_repro_direction_change_kickstart);
+  RUN_TEST(test_cv49_zero_only_kickstart_works);
+  RUN_TEST(test_cv49_zero_detailed_simulation);
+  RUN_TEST(test_cv49_zero_with_stop_start);
   return UNITY_END();
 }

--- a/xDuinoRails_MM/MotorControl.cpp
+++ b/xDuinoRails_MM/MotorControl.cpp
@@ -162,6 +162,7 @@ void MotorControl::update(int pwm, MM2DirectionState dir) {
   if (isKickstarting_priv) {
     if (now - kickstartBegin >= KICK_MAX_TIME) {
       isKickstarting_priv = false;
+      writeMotorHardware(targetPwm, currDirection);
       logger.println("Motor: Kickstart ended (timeout)", LogCategory::PWM);
     } else {
       bool bemfEnabled = (cvManager.getCv(CV_BEMF_CONFIG) & 0x01);
@@ -175,6 +176,7 @@ void MotorControl::update(int pwm, MM2DirectionState dir) {
 
         if (currentBEMF > BEMF_THRESHOLD) {
           isKickstarting_priv = false;
+          writeMotorHardware(targetPwm, currDirection);
           logger.println("Motor: Kickstart ended (BEMF)", LogCategory::PWM);
         }
       }


### PR DESCRIPTION
This change addresses an issue where the motor would stall after the kickstart phase if BEMF was disabled (CV 49 = 0). The fix involves explicitly writing the target PWM to the hardware immediately when the kickstart phase ends (due to timeout or BEMF threshold detection). New native tests were added to verify the transition from kickstart to target speed in open-loop mode.

Fixes #225

---
*PR created automatically by Jules for task [2015109316384415383](https://jules.google.com/task/2015109316384415383) started by @chatelao*