### PR TITLE
Update CLI commands in User Manual

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -87,6 +87,8 @@ The decoder provides a simple command line interface via the USB Serial port (11
 | `d f` | Sets the direction to **Forward**. | `d f` |
 | `d b` | Sets the direction to **Backward**. | `d b` |
 | `f <0/1>` | Sets Function 1 (F1) to Off (0) or On (1). | `f 1` (Turn on F1) |
-| `L` or `l` | Toggles USB Serial logging (On/Off). | `L` |
+| `L` or `l` | Toggles Master USB Serial logging (On/Off). | `L` |
+| `L <cat>` | Toggles logging for a specific category: `p` (Protocol), `w` (PWM), `c` (CV), `b` (BEMF), `h` (HighSpeed CSV). | `L p` |
+| `h` or `?` | Shows the help summary. | `h` |
 
 > **Note:** Commands are executed upon pressing Enter.


### PR DESCRIPTION
This PR updates the `USER_MANUAL.md` to include all currently supported CLI commands. Specifically, it adds the help commands (`h`, `?`) and provides details for the logging sub-options (`p`, `w`, `c`, `b`, `h`) used with the `L` command. These changes ensure the documentation is consistent with the `SerialConsole` implementation.

Fixes #245

---
*PR created automatically by Jules for task [16427567724890711725](https://jules.google.com/task/16427567724890711725) started by @chatelao*