### PR TITLE
Update default PI gains for BEMF control

### DIFF
--- a/BETTER_CONFIG.md
+++ b/BETTER_CONFIG.md
@@ -34,7 +34,7 @@ The output is prefixed with `CSV,` and follows this structure:
 
 ## Tuning Procedure
 
-1.  **Baseline:** Set CV 54 (K) and CV 55 (I) to default values (e.g., K=32, I=24).
+1.  **Baseline:** Set CV 54 (K) and CV 55 (I) to default values (e.g., K=16, I=12).
 2.  **Capture Data:** Enable high-speed logging (`l h`) and start the locomotive at a medium speed step (e.g., `s 7`).
 3.  **Analyze Step Response:**
     *   Observe how quickly `currentBEMF` reaches the target.
@@ -47,7 +47,7 @@ The output is prefixed with `CSV,` and follows this structure:
 
 | Motor Type | CV 52 | CV 54 (K) | CV 55 (I) |
 | :--- | :--- | :--- | :--- |
-| Standard DC | 0 | 32 | 24 |
+| Standard DC | 0 | 16 | 12 |
 | Faulhaber | 1 | 16 | 12 |
 | Maxon | 2 | 48 | 32 |
 

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -63,8 +63,8 @@ This table specifies the minimal supported Configuration Variables (CVs) for thi
 | 🔴 | 34 | Rear Light (F0r) | Standard | 2 | Bit 1 on: Switches physical output B. |
 | 🔄 | 49 | BEMF Config | Standard | 1 | Bit 0: Enable BEMF sensing and Load Compensation. |
 | 🏎️ | 52 | Motor Type | Standard | 0 | Selects the motor characteristics curve. 0 = Standard DC, 1 = Faulhaber, 2 = Maxon. |
-| 🎛️ | 54 | BEMF K | Standard | 32 | Proportional gain for the BEMF PI controller. |
-| 🎛️ | 55 | BEMF I | Standard | 24 | Integral gain for the BEMF PI controller. |
+| 🎛️ | 54 | BEMF K | Standard | 16 | Proportional gain for the BEMF PI controller. |
+| 🎛️ | 55 | BEMF I | Standard | 12 | Integral gain for the BEMF PI controller. |
 | 🆔 | 107 | Ext. ID (High) | Meta | 1 | Identifier for DecoderDB (part 1 of ID 266). |
 | 🆔 | 108 | Ext. ID (Low) | Meta | 10 | Identifier for DecoderDB (part 2 of ID 266). |
 | 🪵 | 250 | Debug Enable | Standard | 1 | 0 = Disabled, 1 = Enabled (default). Outputs debug info to Serial USB. |

--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -75,6 +75,8 @@ void test_cv_manager_defaults(void) {
   TEST_ASSERT_EQUAL(2, cvManager.getCv(CV_REAR_LIGHT_F0R));
   TEST_ASSERT_EQUAL(1, cvManager.getCv(CV_EXT_ID_HIGH));
   TEST_ASSERT_EQUAL(10, cvManager.getCv(CV_EXT_ID_LOW));
+  TEST_ASSERT_EQUAL(16, cvManager.getCv(CV_BEMF_K));
+  TEST_ASSERT_EQUAL(12, cvManager.getCv(CV_BEMF_I));
   TEST_ASSERT_EQUAL(1, cvManager.getCv(CV_DEBUG_ENABLE));
 }
 

--- a/xDuinoRails_MM/CvManager.cpp
+++ b/xDuinoRails_MM/CvManager.cpp
@@ -96,8 +96,8 @@ void CvManager::initCv() {
     EEPROM.write(CV_FRONT_LIGHT_F0F, 1);
     EEPROM.write(CV_REAR_LIGHT_F0R, 2);
     EEPROM.write(CV_BEMF_CONFIG, 1);
-    EEPROM.write(CV_BEMF_K, 32);
-    EEPROM.write(CV_BEMF_I, 24);
+    EEPROM.write(CV_BEMF_K, 16);
+    EEPROM.write(CV_BEMF_I, 12);
     EEPROM.write(CV_MOTOR_TYPE, 0);
     EEPROM.write(CV_EXT_ID_HIGH, 1);
     EEPROM.write(CV_EXT_ID_LOW, 10);


### PR DESCRIPTION
Reduced default PI gains for BEMF control based on high-speed logging analysis to improve motor stability and reduce oscillations. Updated CV 54 (K) from 32 to 16 and CV 55 (I) from 24 to 12. documentation and tests have been updated accordingly.

Fixes #261

---
*PR created automatically by Jules for task [2793387427823042522](https://jules.google.com/task/2793387427823042522) started by @chatelao*