### PR TITLE
Add median-of-3 filter for BEMF sensing to handle collector gaps

### DIFF
--- a/MOTOR_CONTROL_AUDIT.md
+++ b/MOTOR_CONTROL_AUDIT.md
@@ -53,6 +53,7 @@ To overcome initial motor friction, the firmware implements a kickstart phase wh
   2. A blanking delay of **500 microseconds** (`delayMicroseconds(500)`) is applied to allow inductive spikes to decay.
   3. Analog values are sampled from both BEMF pins.
   4. The absolute difference between the samples is returned.
+* **Filtering:** A **median-of-3 filter** is applied to the raw BEMF samples in `MotorControl::update()`. This filter effectively rejects single-sample glitches, such as those caused by collector gaps or brush sparking, preventing aggressive PI controller responses to transient errors.
 
 ### Termination Conditions
 The kickstart phase ends immediately when either of these conditions is met:

--- a/test/test_native/test_bemf_glitch.cpp
+++ b/test/test_native/test_bemf_glitch.cpp
@@ -1,0 +1,133 @@
+#include "CvManagerMock.h"
+#include "MotorControl.h"
+#include "RP2040.h"
+#include <unity.h>
+#include <map>
+#include <vector>
+
+extern std::map<uint8_t, int> analog_write_values;
+extern std::map<uint8_t, int> analog_read_values;
+extern void advance_millis(unsigned long ms);
+
+void test_bemf_collector_gap_glitch(void) {
+  CvManagerMock cvManager;
+  cvManager.setCv(CV_START_VOLTAGE, 10);  // PWM 40
+  cvManager.setCv(CV_MAXIMUM_SPEED, 255); // PWM 1023
+  cvManager.setCv(CV_MEDIUM_SPEED, 0);    // Midpoint PWM 531
+  cvManager.setCv(CV_BEMF_CONFIG, 1);     // Enable BEMF
+  cvManager.setCv(CV_BEMF_K, 16);         // K=16 -> factor 1
+  cvManager.setCv(CV_BEMF_I, 0);          // Disable I for pure glitch analysis
+  cvManager.setCv(CV_MOTOR_TYPE, 0);
+
+  MotorControl motor(cvManager, 10, 11, 2, 3, 12);
+  motor.setup();
+
+  // Set speed to step 7 (targetPwm = 531)
+  motor.setSpeed(7, MM2DirectionState_Forward);
+  advance_millis(150); // Pass kickstart
+
+  // Warm up filter (3 samples)
+  analog_read_values[2] = 2124;
+  analog_read_values[3] = 0;
+  for (int i = 0; i < 3; i++) {
+    advance_millis(20);
+    motor.setSpeed(7, MM2DirectionState_Forward);
+  }
+
+  // No adjustment expected now that filter is warm
+  TEST_ASSERT_EQUAL(531, analog_write_values[10]);
+
+  // Collector gap glitch: BEMF drops to 0 for ONE sample
+  analog_read_values[2] = 0;
+  advance_millis(20);
+  motor.setSpeed(7, MM2DirectionState_Forward);
+
+  // Median of {2124, 2124, 0} is 2124.
+  // The glitch should be IGNORED.
+  TEST_ASSERT_EQUAL(531, analog_write_values[10]);
+
+  // Recovery: BEMF returns to normal
+  analog_read_values[2] = 2124;
+  advance_millis(20);
+  motor.setSpeed(7, MM2DirectionState_Forward);
+
+  TEST_ASSERT_EQUAL(531, analog_write_values[10]);
+}
+
+void test_bemf_collector_gap_persistent_failure(void) {
+  CvManagerMock cvManager;
+  cvManager.setCv(CV_START_VOLTAGE, 10);
+  cvManager.setCv(CV_MAXIMUM_SPEED, 255);
+  cvManager.setCv(CV_MEDIUM_SPEED, 0);
+  cvManager.setCv(CV_BEMF_CONFIG, 1);
+  cvManager.setCv(CV_BEMF_K, 16); // K=1
+  cvManager.setCv(CV_BEMF_I, 0);
+  cvManager.setCv(CV_MOTOR_TYPE, 0);
+
+  MotorControl motor(cvManager, 10, 11, 2, 3, 12);
+  motor.setup();
+
+  motor.setSpeed(7, MM2DirectionState_Forward);
+  advance_millis(150);
+
+  // Warm up
+  analog_read_values[2] = 2124;
+  for (int i = 0; i < 3; i++) {
+    advance_millis(20);
+    motor.setSpeed(7, MM2DirectionState_Forward);
+  }
+
+  // Persistent drop to 0 (more than 1 sample)
+  analog_read_values[2] = 0;
+  advance_millis(20);
+  motor.setSpeed(7, MM2DirectionState_Forward); // History: {2124, 2124, 0} -> Median 2124
+  TEST_ASSERT_EQUAL(531, analog_write_values[10]);
+
+  advance_millis(20);
+  motor.setSpeed(7, MM2DirectionState_Forward); // History: {2124, 0, 0} -> Median 0
+  // Now it should react
+  // targetBEMF = 2124, filteredBEMF = 0 -> adjustment = 2124
+  TEST_ASSERT_EQUAL(1023, analog_write_values[10]);
+}
+
+void test_bemf_collector_gap_with_integral_filtered(void) {
+  CvManagerMock cvManager;
+  cvManager.setCv(CV_START_VOLTAGE, 10);
+  cvManager.setCv(CV_MAXIMUM_SPEED, 255);
+  cvManager.setCv(CV_MEDIUM_SPEED, 0);
+  cvManager.setCv(CV_BEMF_CONFIG, 1);
+  cvManager.setCv(CV_BEMF_K, 16); // K=1
+  cvManager.setCv(CV_BEMF_I, 16); // I=16 -> factor 0.25
+  cvManager.setCv(CV_MOTOR_TYPE, 0);
+
+  MotorControl motor(cvManager, 10, 11, 2, 3, 12);
+  motor.setup();
+
+  motor.setSpeed(7, MM2DirectionState_Forward);
+  advance_millis(150);
+
+  // Warm up
+  analog_read_values[2] = 2124;
+  for (int i = 0; i < 3; i++) {
+    advance_millis(20);
+    motor.setSpeed(7, MM2DirectionState_Forward);
+  }
+
+  // Stable
+  TEST_ASSERT_EQUAL(531, analog_write_values[10]);
+
+  // Single sample glitch
+  analog_read_values[2] = 0;
+  advance_millis(20);
+  motor.setSpeed(7, MM2DirectionState_Forward);
+
+  // Filtered BEMF should still be 2124. No integral error should be added.
+  TEST_ASSERT_EQUAL(531, analog_write_values[10]);
+
+  // Recovery
+  analog_read_values[2] = 2124;
+  advance_millis(20);
+  motor.setSpeed(7, MM2DirectionState_Forward);
+
+  TEST_ASSERT_EQUAL(531, analog_write_values[10]);
+}

--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -38,6 +38,9 @@ void test_cv49_zero_with_direction_change(void);
 void test_high_speed_logging(void);
 void test_pwm_frequency_defaults(void);
 void test_pwm_frequency_override(void);
+void test_bemf_collector_gap_glitch(void);
+void test_bemf_collector_gap_persistent_failure(void);
+void test_bemf_collector_gap_with_integral_filtered(void);
 
 // Mock implementation for RP2040 reboot
 bool   reboot_called = false;
@@ -924,5 +927,8 @@ int main(int argc, char **argv) {
   RUN_TEST(test_high_speed_logging);
   RUN_TEST(test_pwm_frequency_defaults);
   RUN_TEST(test_pwm_frequency_override);
+  RUN_TEST(test_bemf_collector_gap_glitch);
+  RUN_TEST(test_bemf_collector_gap_persistent_failure);
+  RUN_TEST(test_bemf_collector_gap_with_integral_filtered);
   return UNITY_END();
 }

--- a/test/test_native/test_motor_analysis.cpp
+++ b/test/test_native/test_motor_analysis.cpp
@@ -4,6 +4,7 @@
 #include <unity.h>
 
 extern std::map<uint8_t, int> analog_write_values;
+extern std::map<uint8_t, int> analog_read_values;
 extern void advance_millis(unsigned long ms);
 
 void test_motor_pwm_mapping_detailed(void) {
@@ -103,39 +104,41 @@ void test_motor_bemf_pi_control(void) {
   motor.setSpeed(7, MM2DirectionState_Forward);
   advance_millis(150); // Pass kickstart
 
-  // targetBEMF = 531 * 4 = 2124
-  // Simulate currentBEMF = 2000 (Load detected, engine slow)
-  // error = 2124 - 2000 = 124
-  // bemfErrorSum = 124
-  // adjustment = (124 * 32 / 16) + (124 * 64 / 64) = 248 + 124 = 372
+  // Warm up filter (3 samples)
   analog_read_values[2] = 2000;
   analog_read_values[3] = 0;
-  advance_millis(20);
-  motor.setSpeed(7, MM2DirectionState_Forward);
+  for (int i = 0; i < 3; i++) {
+    advance_millis(20);
+    motor.setSpeed(7, MM2DirectionState_Forward);
+  }
 
-  // finalPwm = 531 + 372 = 903
-  TEST_ASSERT_EQUAL(903, analog_write_values[10]);
+  // targetBEMF = 531 * 4 = 2124
+  // filteredBEMF = 2000
+  // error = 2124 - 2000 = 124
+  // bemfErrorSum = 124 (after warmup) + 124 + 124 + 124 = 496
+  // Wait, bemfErrorSum accumulates every update.
+  // Let's reset the sum for predictable testing
+  // Actually we can't reset it from here. Let's calculate carefully.
 
-  // Second update with same BEMF
-  // error = 124
-  // bemfErrorSum = 124 + 124 = 248
-  // adjustment = (124 * 32 / 16) + (248 * 64 / 64) = 248 + 248 = 496
-  advance_millis(20);
-  motor.setSpeed(7, MM2DirectionState_Forward);
+  // Warmup step 1: bemfErrorSum = 124. adj = (124*2) + (124*1) = 372. finalPwm = 531+372=903.
+  // Warmup step 2: bemfErrorSum = 248. adj = 248 + 248 = 496. finalPwm = 531+496=1027->1023.
+  // Warmup step 3: bemfErrorSum = 372. adj = 248 + 372 = 620. finalPwm = 1023.
 
-  // finalPwm = 531 + 496 = 1027 (clamped to 1023)
   TEST_ASSERT_EQUAL(1023, analog_write_values[10]);
 
   // Now simulate overspeed (e.g. going downhill)
-  // currentBEMF = 2500
-  // targetBEMF = 2124
-  // error = 2124 - 2500 = -376
-  // bemfErrorSum = 248 - 376 = -128
-  // adjustment = (-376 * 32 / 16) + (-128 * 64 / 64) = -752 - 128 = -880
   analog_read_values[2] = 2500;
+  // Step 1: history {2000, 2000, 2500} -> median 2000. Error remains 124. bemfErrorSum = 496. adj = 248 + 496 = 744. finalPwm = 1023.
   advance_millis(20);
   motor.setSpeed(7, MM2DirectionState_Forward);
+  TEST_ASSERT_EQUAL(1023, analog_write_values[10]);
 
-  // finalPwm = 531 - 880 = -349 (clamped to 0)
+  // Step 2: history {2000, 2500, 2500} -> median 2500.
+  // targetBEMF = 2124, filteredBEMF = 2500 -> error = -376
+  // bemfErrorSum = 496 - 376 = 120
+  // adjustment = (-376 * 2) + (120 * 1) = -752 + 120 = -632
+  // finalPwm = 531 - 632 = -101 -> clamped to 0
+  advance_millis(20);
+  motor.setSpeed(7, MM2DirectionState_Forward);
   TEST_ASSERT_EQUAL(0, analog_write_values[10]);
 }

--- a/xDuinoRails_MM/MotorControl.cpp
+++ b/xDuinoRails_MM/MotorControl.cpp
@@ -21,6 +21,7 @@ MotorControl::MotorControl(CvManager &cvManager, int pinA, int pinB, int bemfA,
   previousPwm         = 0;
   bemfErrorSum        = 0;
   lastAdjustment      = 0;
+  for (int i = 0; i < 3; i++) bemfHistory[i] = 0;
 
   lastWrittenPwm      = -1;
   lastWrittenDir      = MM2DirectionState_Unavailable;
@@ -160,6 +161,7 @@ void MotorControl::update(int pwm, MM2DirectionState dir) {
     currDirection = targetDirection;
     bemfErrorSum   = 0;
     lastAdjustment = 0;
+    for (int i = 0; i < 3; i++) bemfHistory[i] = 0;
   }
 
   if (previousPwm == 0 && targetPwm > 0 && KICK_MAX_TIME > 0) {
@@ -177,6 +179,9 @@ void MotorControl::update(int pwm, MM2DirectionState dir) {
     if (now - kickstartBegin >= KICK_MAX_TIME) {
       isKickstarting_priv = false;
       logger.println("Motor: Kickstart ended (timeout)", LogCategory::PWM);
+      // Seed history with current reading
+      int currentBEMF = readBEMF();
+      for (int i = 0; i < 3; i++) bemfHistory[i] = currentBEMF;
       // Ensure target PWM is applied immediately after kickstart ends
       writeMotorHardware(targetPwm, currDirection);
     } else {
@@ -192,6 +197,10 @@ void MotorControl::update(int pwm, MM2DirectionState dir) {
         if (currentBEMF > BEMF_THRESHOLD) {
           isKickstarting_priv = false;
           logger.println("Motor: Kickstart ended (BEMF)", LogCategory::PWM);
+
+          // Seed median filter with the first valid reading to avoid initial glitch
+          for (int i = 0; i < 3; i++) bemfHistory[i] = currentBEMF;
+
           // Ensure target PWM is applied immediately after kickstart ends
           writeMotorHardware(targetPwm, currDirection);
         }
@@ -209,6 +218,7 @@ void MotorControl::update(int pwm, MM2DirectionState dir) {
       bemfErrorSum   = 0;
       lastAdjustment = 0;
       targetPwm      = 0; // Force previousPwm to 0 for next call to trigger kickstart
+      for (int i = 0; i < 3; i++) bemfHistory[i] = 0;
     } else {
       int finalPwm = targetPwm;
 
@@ -218,17 +228,32 @@ void MotorControl::update(int pwm, MM2DirectionState dir) {
           int currentBEMF = readBEMF();
           lastBemfMeasure = now;
 
-          lastMeasuredBemf = currentBEMF;
-          bemfSum += currentBEMF;
+          // Simple median-of-3 filter to reject collector gap spikes
+          // If history is empty, seed it with the first reading
+          if (bemfHistory[0] == 0 && bemfHistory[1] == 0 && bemfHistory[2] == 0) {
+            for (int i = 0; i < 3; i++) bemfHistory[i] = currentBEMF;
+          } else {
+            bemfHistory[0] = bemfHistory[1];
+            bemfHistory[1] = bemfHistory[2];
+            bemfHistory[2] = currentBEMF;
+          }
+
+          int filteredBEMF;
+          int a = bemfHistory[0];
+          int b = bemfHistory[1];
+          int c = bemfHistory[2];
+
+          if ((a <= b && b <= c) || (c <= b && b <= a)) filteredBEMF = b;
+          else if ((b <= a && a <= c) || (c <= a && a <= b)) filteredBEMF = a;
+          else filteredBEMF = c;
+
+          lastMeasuredBemf = filteredBEMF;
+          bemfSum += filteredBEMF;
           bemfCount++;
 
-
           // PI-Regler
-          // Ziel-BEMF: Wir nehmen an, dass BEMF proportional zu PWM ist.
-          // PWM 0-1023 -> BEMF 0-4095 (12-bit ADC).
-          // Ein Ziel-BEMF von targetPwm * 4 ist eine grobe Annäherung.
           int targetBEMF = targetPwm * 4;
-          int error      = targetBEMF - currentBEMF;
+          int error      = targetBEMF - filteredBEMF;
 
           uint8_t K = cvManager.getCv(CV_BEMF_K);
           uint8_t I = cvManager.getCv(CV_BEMF_I);
@@ -240,7 +265,7 @@ void MotorControl::update(int pwm, MM2DirectionState dir) {
           if (bemfErrorSum < -10000)
             bemfErrorSum = -10000;
 
-          lastAdjustment = (error * K / 16) + (bemfErrorSum * I / 64);
+          lastAdjustment = ((long)error * K / 16) + ((long)bemfErrorSum * I / 64);
 
           if (logger.isHighSpeedEnabled()) {
             logger.printf(LogCategory::HighSpeed, "CSV,%lu,%d,%d,%d,%ld,%d\n",

--- a/xDuinoRails_MM/MotorControl.h
+++ b/xDuinoRails_MM/MotorControl.h
@@ -36,6 +36,7 @@ private:
   int               previousPwm;
   long              bemfErrorSum;
   int               lastAdjustment;
+  int               bemfHistory[3];
 
   int               lastWrittenPwm;
   MM2DirectionState lastWrittenDir;


### PR DESCRIPTION
### BEMF Collector Gap Handling Verification and Improvement

This PR addresses the handling of Back-EMF (BEMF) errors caused by collector gaps (transient signal loss at the motor brushes).

#### Findings:
Initial analysis and native test simulations revealed that a single-sample drop in BEMF (to 0) caused the PI controller to perceive a motor stall, resulting in an immediate and aggressive PWM spike to 100%. This led to erratic motor behavior and potential integral windup.

#### Improvements:
1.  **Median-of-3 Filter:** Implemented a simple but effective median filter for BEMF samples in `MotorControl::update()`. This filter effectively rejects single-sample spikes or drops by selecting the middle value of the last three readings.
2.  **Filter Seeding:** Added logic to "seed" the filter history with the first valid reading upon kickstart termination or motor direction changes. This ensures the filter is "warm" and stable from the moment the control loop starts.
3.  **Enhanced Native Tests:** Created a new test suite `test_bemf_glitch.cpp` that specifically simulates:
    *   Single-sample BEMF drops (collector gaps) are now ignored (PWM remains stable).
    *   Persistent BEMF failures (>= 2 samples) are still correctly detected and compensated for.
    *   Integral windup is prevented during transient glitches.
4.  **Documentation:** Updated `MOTOR_CONTROL_AUDIT.md` to document the new filtering mechanism.

#### Verification:
*   Executed `pio test -e native`: All 39 test cases passed, including the new glitch rejection tests and updated PI control analysis.
*   Verified production build for Seeed XIAO RP2040 via `pio run`.
*   Refactored existing BEMF tests to account for the 3-sample "warm-up" period required by the median filter.

Fixes #262

---
*PR created automatically by Jules for task [808809375634969946](https://jules.google.com/task/808809375634969946) started by @chatelao*