### PR TITLE
Fix motor jumping and improve PID stability

### DIFF
--- a/test/test_native/test_bemf_stability.cpp
+++ b/test/test_native/test_bemf_stability.cpp
@@ -1,0 +1,94 @@
+#include "CvManagerMock.h"
+#include "MotorControl.h"
+#include "RP2040.h"
+#include <unity.h>
+
+extern std::map<uint8_t, int> analog_write_values;
+extern std::map<uint8_t, int> analog_read_values;
+extern void advance_millis(unsigned long ms);
+
+/**
+ * Test to verify the stability of the PI controller and the effectiveness of the reduced integral windup limit.
+ */
+void test_bemf_stability_integral_clamping(void) {
+  CvManagerMock cvManager;
+  cvManager.setCv(CV_START_VOLTAGE, 10);  // PWM 40
+  cvManager.setCv(CV_MAXIMUM_SPEED, 255); // PWM 1023
+  cvManager.setCv(CV_MEDIUM_SPEED, 0);    // Midpoint PWM 531
+  cvManager.setCv(CV_BEMF_CONFIG, 1);     // Enable BEMF
+  cvManager.setCv(CV_BEMF_K, 16);         // K=16 -> factor 1
+  cvManager.setCv(CV_BEMF_I, 64);         // I=64 -> factor 1
+  cvManager.setCv(CV_MOTOR_TYPE, 0);
+
+  MotorControl motor(cvManager, 10, 11, 2, 3, 12);
+  motor.setup();
+
+  // Set speed to step 7 (targetPwm = 531, targetBEMF = 2124)
+  motor.setSpeed(7, MM2DirectionState_Forward);
+  advance_millis(150); // Pass kickstart
+
+  // Simulating a heavily loaded or stalled motor (BEMF = 0)
+  analog_read_values[2] = 0;
+  analog_read_values[3] = 0;
+
+  // Let the controller run for several cycles to accumulate error
+  // Each cycle at 12ms (default for Standard DC)
+  for (int i = 0; i < 100; i++) {
+    advance_millis(15);
+    motor.setSpeed(7, MM2DirectionState_Forward);
+  }
+
+  // With targetBEMF = 2124 and currentBEMF = 0, error = 2124.
+  // After 100 cycles, the integral would normally be 212400.
+  // However, it should be clamped to 4096.
+
+  // Adjustment calculation:
+  // Adjustment = (error * K / 16) + (bemfErrorSum * I / 64)
+  // Adjustment = (2124 * 16 / 16) + (4096 * 64 / 64) = 2124 + 4096 = 6220
+  // finalPwm = 531 + 6220 = 6751 -> clamped to 1023
+
+  TEST_ASSERT_EQUAL(1023, analog_write_values[10]);
+
+  // Now simulate the motor suddenly starting to move very fast (BEMF = 4000)
+  // This simulates the "jump" behavior after the stall is released.
+  // We want to see how quickly the adjustment decreases.
+  analog_read_values[2] = 4000;
+
+  // One cycle:
+  // targetBEMF = 2124, currentBEMF = 4000 -> error = -1876
+  // bemfErrorSum = 4096 - 1876 = 2220
+  // Adjustment = (-1876 * 1) + (2220 * 1) = 344
+  // finalPwm = 531 + 344 = 875
+  advance_millis(15);
+  motor.setSpeed(7, MM2DirectionState_Forward);
+  TEST_ASSERT_EQUAL(875, analog_write_values[10]);
+
+  // Next cycle:
+  // bemfErrorSum = 2220 - 1876 = 344
+  // Adjustment = -1876 + 344 = -1532
+  // finalPwm = 531 - 1532 = -1001 -> clamped to 0
+  advance_millis(15);
+  motor.setSpeed(7, MM2DirectionState_Forward);
+  TEST_ASSERT_EQUAL(0, analog_write_values[10]);
+}
+
+/**
+ * Test to verify that readBEMF properly toggles the shutdown pin.
+ */
+void test_read_bemf_shutdown_toggling(void) {
+  CvManagerMock cvManager;
+  MotorControl motor(cvManager, 10, 11, 2, 3, 12); // shutPin = 12
+  motor.setup();
+
+  // Reset last written value for shutdown pin (D2/12)
+  extern std::map<uint8_t, int> digital_write_values;
+  digital_write_values[12] = 0; // LOW is enabled
+
+  motor.readBEMF();
+
+  // We expect it was set to HIGH (disabled) and then back to LOW (enabled)
+  // The mock digital_write just records the last value.
+  // To properly test this, we would need a sequence recorder, but we can at least
+  // verify it's back to LOW.
+  TEST_ASSERT_EQUAL(0, digital_write_values[12]);
+}

--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -41,6 +41,8 @@ void test_pwm_frequency_override(void);
 void test_bemf_collector_gap_glitch(void);
 void test_bemf_collector_gap_persistent_failure(void);
 void test_bemf_collector_gap_with_integral_filtered(void);
+void test_bemf_stability_integral_clamping(void);
+void test_read_bemf_shutdown_toggling(void);
 
 // Mock implementation for RP2040 reboot
 bool   reboot_called = false;
@@ -932,5 +934,7 @@ int main(int argc, char **argv) {
   RUN_TEST(test_bemf_collector_gap_glitch);
   RUN_TEST(test_bemf_collector_gap_persistent_failure);
   RUN_TEST(test_bemf_collector_gap_with_integral_filtered);
+  RUN_TEST(test_bemf_stability_integral_clamping);
+  RUN_TEST(test_read_bemf_shutdown_toggling);
   return UNITY_END();
 }

--- a/xDuinoRails_MM/MotorControl.cpp
+++ b/xDuinoRails_MM/MotorControl.cpp
@@ -260,10 +260,10 @@ void MotorControl::update(int pwm, MM2DirectionState dir) {
 
           bemfErrorSum += error;
           // Begrenzung des Integrals, um Windup zu verhindern
-          if (bemfErrorSum > 10000)
-            bemfErrorSum = 10000;
-          if (bemfErrorSum < -10000)
-            bemfErrorSum = -10000;
+          if (bemfErrorSum > 4096)
+            bemfErrorSum = 4096;
+          if (bemfErrorSum < -4096)
+            bemfErrorSum = -4096;
 
           lastAdjustment = ((long)error * K / 16) + ((long)bemfErrorSum * I / 64);
 
@@ -359,11 +359,18 @@ void MotorControl::writeMotorHardware(int pwm, MM2DirectionState dir) {
 }
 
 int MotorControl::readBEMF() {
+  if (shutPin_priv != -1) {
+    digitalWrite(shutPin_priv, HIGH); // Disable H-bridge (coast)
+  }
   digitalWrite(pinA_priv, LOW);
   digitalWrite(pinB_priv, LOW);
   delayMicroseconds(500);
   int valA = analogRead(bemfA_priv);
   int valB = analogRead(bemfB_priv);
+
+  if (shutPin_priv != -1) {
+    digitalWrite(shutPin_priv, LOW); // Re-enable H-bridge
+  }
 
   // Since we touched the pins, invalidate the write cache
   lastWrittenPwm = -1;

--- a/xDuinoRails_MM/MotorControl.cpp
+++ b/xDuinoRails_MM/MotorControl.cpp
@@ -362,8 +362,12 @@ int MotorControl::readBEMF() {
   if (shutPin_priv != -1) {
     digitalWrite(shutPin_priv, HIGH); // Disable H-bridge (coast)
   }
+  // Ensure PWM is fully off and pins are LOW for Stand-by/Coast mode
+  analogWrite(pinA_priv, 0);
+  analogWrite(pinB_priv, 0);
   digitalWrite(pinA_priv, LOW);
   digitalWrite(pinB_priv, LOW);
+
   delayMicroseconds(500);
   int valA = analogRead(bemfA_priv);
   int valB = analogRead(bemfB_priv);

--- a/xDuinoRails_MM/MotorControl.h
+++ b/xDuinoRails_MM/MotorControl.h
@@ -14,11 +14,11 @@ public:
   void              stop();
   bool              isKickstarting();
   MM2DirectionState getCurrentDirection();
+  int               readBEMF();
 
 private:
   void update(int targetPwm, MM2DirectionState targetDir);
   void writeMotorHardware(int pwm, MM2DirectionState dir);
-  int  readBEMF();
 
   CvManager        &cvManager;
   int               pinA_priv;


### PR DESCRIPTION
This change addresses the "jumping" behavior observed after a factory reset. The analysis of the logs showed that the PID integral term (`bemfErrorSum`) was hitting an excessive limit of 10,000, causing massive overshoots. Additionally, the previous BEMF sensing method effectively braked the motor during measurement, collapsing the signal.

Key changes:
1. **H-Bridge Shutdown for Coasting:** The `readBEMF` function now toggles the `shutPin_priv` (if configured) to put the driver in High-Z mode during the 500µs sampling window. This allows the motor to act as a generator and provide accurate BEMF voltage.
2. **Reduced Integral Clamping:** The integral error sum is now clamped to +/- 4096. This provides enough authority for load compensation while ensuring the controller can shed accumulated error quickly, preventing the "jumping" effect.
3. **Enhanced Testing:** Added a new test suite that simulates motor stalls and release scenarios to ensure the PI controller remains stable. All 41 native tests pass.

Fixes #265

---
*PR created automatically by Jules for task [17991490305958680334](https://jules.google.com/task/17991490305958680334) started by @chatelao*