### PR TITLE
Integrate Renode simulation for automated RP2040 verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,23 @@ jobs:
         run: pio test -e native --without-uploading
 
       - name: Build firmware
-        run: pio run -e seeed_xiao_rp2040 -e seeed_xiao_esp32c6
+        run: pio run -e seeed_xiao_rp2040 -e seeed_xiao_esp32c6 -e seeed_xiao_rp2040_renode
+
+  renode-simulation:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk2.0-0 libglib2.0-0 libfontconfig1 libx11-6 libxcursor1 libxext6 libxi6 libxrender1 libxtst6
+          pip install platformio robotframework==6.1
+      - name: Run Renode tests
+        run: ./run_renode_tests.sh
 
   arduino-cli-build:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,11 @@
 .pio
+test/renode-bin/
+venv-renode/
+*.log
+robot_outputs/
+snapshots/
+log.html
+output.xml
+report.html
+robot_output.xml
 .vscode

--- a/RENODE_GAPS.md
+++ b/RENODE_GAPS.md
@@ -1,0 +1,17 @@
+# RENODE_GAPS.md
+
+This document identifies known gaps and limitations in the current Renode simulation environment for xDuinoRails_MM.
+
+## Hardware Support
+- **PIO (Programmable I/O):** The RP2040 PIO block is not fully modeled in the standard Renode release. Complex timing-dependent protocols (like NeoPixel or high-speed DCC decoding) may require custom C#/Python extensions.
+- **USB Device:** Serial over USB is not simulated. All debug output and CLI interaction are redirected to Hardware UART0 (Serial1).
+- **Dual-Core:** While Renode supports multicore RP2040, the current simulation is focused on Core 0.
+
+## Protocol & Signal
+- **DCC/MM Injection:** There is no built-in "MM Signal Generator" in Renode. Bitstreams must be manually injected via GPIO state changes or Python scripts.
+- **BEMF Feedback:** Motor BEMF is not automatically calculated based on PWM duty cycle. ADC values for BEMF must be predefined or updated via scripts during simulation.
+- **RailCom:** High-speed RailCom feedback (cutouts and transmission) is not currently simulated.
+
+## Testing
+- **Robot Framework:** Timing in Robot Framework tests can be sensitive to the host machine's performance. `Wait For Line On Uart` timeouts should be generous.
+- **Graphic Output:** Visual representation of LEDs and NeoPixels is limited to log messages or analyzer windows.

--- a/ROADMAP_RENODE.md
+++ b/ROADMAP_RENODE.md
@@ -1,0 +1,25 @@
+# ROADMAP_RENODE.md
+
+This document outlines the phased integration of Renode simulation for the xDuinoRails_MM project.
+
+## Phase 1: Basic UART and CLI (Completed)
+- [x] Initial Renode setup for RP2040.
+- [x] Mapping XIAO RP2040 UART0 for Serial Console access.
+- [x] Integration with Robot Framework for automated CLI testing.
+- [x] CI/CD pipeline integration.
+
+## Phase 2: Peripherals and Motor Feedback (Ongoing)
+- [ ] Implement virtual Motor feedback (PWM to Speed/BEMF).
+- [ ] Verify Light outputs (Front/Rear/Internal) via GPIO states.
+- [ ] Basic ADC simulation for BEMF readings.
+- [ ] Stub DCC signal input via GPIO buttons/scripts.
+
+## Phase 3: Protocol Injection (Planned)
+- [ ] Inject Märklin Motorola (MM) bitstreams into the simulation via GPIO.
+- [ ] Verify `ProtocolHandler` timing and bit detection in a virtual environment.
+- [ ] End-to-end testing: DCC Command -> Protocol Handler -> Motor Speed change.
+
+## Phase 4: Full System Verification (Future)
+- [ ] Multi-node simulation (Command Station + Decoders).
+- [ ] RailCom feedback simulation.
+- [ ] NeoPixel protocol simulation (if supported by Renode extensions).

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,6 +21,13 @@ lib_deps =
 test_build_src = true
 test_ignore = test_native
 
+[env:seeed_xiao_rp2040_renode]
+extends = env:seeed_xiao_rp2040
+build_flags =
+    ${env:seeed_xiao_rp2040.build_flags}
+    -DRENODE_SIMULATION
+    -DDEBUG_SERIAL=Serial1
+
 [env:native]
 platform = native
 test_framework = unity

--- a/run_renode_tests.sh
+++ b/run_renode_tests.sh
@@ -22,7 +22,10 @@ pio run -e seeed_xiao_rp2040_renode
 # 3. Run Robot Framework tests
 echo "Running Renode simulation tests..."
 # Renode's robot runner is usually called 'renode-test'
-# We might need to install robotframework if not present in the environment
+# We need to install robotframework and Renode's test dependencies
 pip install robotframework==6.1
+if [ -f "$RENODE_DIR/tests/requirements.txt" ]; then
+    pip install -r "$RENODE_DIR/tests/requirements.txt"
+fi
 
 renode-test test/renode/tests/cli_tests.robot

--- a/run_renode_tests.sh
+++ b/run_renode_tests.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+# Configuration
+RENODE_VERSION="1.16.1"
+RENODE_DIR="test/renode-bin"
+RENODE_URL="https://github.com/renode/renode/releases/download/v${RENODE_VERSION}/renode-${RENODE_VERSION}.linux-portable.tar.gz"
+
+# 1. Download Renode if not present
+if [ ! -d "$RENODE_DIR" ]; then
+    echo "Downloading Renode v${RENODE_VERSION}..."
+    mkdir -p "$RENODE_DIR"
+    curl -L "$RENODE_URL" | tar -xz -C "$RENODE_DIR" --strip-components=1
+fi
+
+export PATH="$PWD/$RENODE_DIR:$PATH"
+
+# 2. Build firmware for Renode environment
+echo "Building firmware for Renode..."
+pio run -e seeed_xiao_rp2040_renode
+
+# 3. Run Robot Framework tests
+echo "Running Renode simulation tests..."
+# Renode's robot runner is usually called 'renode-test'
+# We might need to install robotframework if not present in the environment
+pip install robotframework==6.1
+
+renode-test test/renode/tests/cli_tests.robot

--- a/test/renode/boards/seeed_xiao_rp2040.repl
+++ b/test/renode/boards/seeed_xiao_rp2040.repl
@@ -1,0 +1,43 @@
+using "../cores/rp2040.repl"
+
+// Seeed Studio XIAO RP2040 Pinout mapping for xDuinoRails_MM
+
+led_f0f: Miscellaneous.LED @ gpio 9
+led_f0b: Miscellaneous.LED @ gpio 10
+
+led_int_red: Miscellaneous.LED @ gpio 15
+led_int_blue: Miscellaneous.LED @ gpio 16
+neopixel: Miscellaneous.LED @ gpio 12
+
+gpio:
+    9 -> led_f0f@0
+    10 -> led_f0b@0
+    15 -> led_int_red@0
+    16 -> led_int_blue@0
+    12 -> neopixel@0
+
+// Motor pins
+motor_a: Miscellaneous.LED @ gpio 7
+motor_b: Miscellaneous.LED @ gpio 8
+motor_shut: Miscellaneous.LED @ gpio 2
+
+gpio:
+    7 -> motor_a@0
+    8 -> motor_b@0
+    2 -> motor_shut@0
+
+// DCC / BEMF / ACK / RailCom - mostly tags for now or stubbed
+dcc_in: Miscellaneous.Button @ gpio 5
+dcc_ack: Miscellaneous.LED @ gpio 4
+railcom: Miscellaneous.LED @ gpio 6
+
+gpio:
+    5 -> dcc_in@0
+    4 -> dcc_ack@0
+    6 -> railcom@0
+
+// BEMF ADC Pins
+// GPIO 26 -> A0 (BEMF A)
+// GPIO 27 -> A1 (BEMF B)
+// GPIO 28 -> A2 (MOTOR_SHUT/D2)
+// GPIO 29 -> A3 (FUNC_SHUT/D3)

--- a/test/renode/cores/rp2040.repl
+++ b/test/renode/cores/rp2040.repl
@@ -1,0 +1,162 @@
+bootrom0: Memory.MappedMemory @ sysbus 0x00000000
+    size: 0x4000
+
+flash0: Memory.MappedMemory @ sysbus 0x10000000
+    size: 0x200000
+
+flash0_al1: Memory.MemoryAlias @ sysbus 0x13000000
+    address: 0x10000000
+    size: 0x200000
+
+
+sram0: Memory.MappedMemory @ sysbus 0x20000000
+    size: 0x42000
+
+
+usbram: Memory.MappedMemory @ sysbus 0x50100000
+    size: 0x1000
+
+cpu0: CPU.CortexM @ sysbus
+    cpuType: "cortex-m0+"
+    id: 0
+    nvic: nvic0
+    PerformanceInMips: 20
+
+cpu1: CPU.CortexM @ sysbus
+    cpuType: "cortex-m0+"
+    id: 1
+    nvic: nvic1
+    PerformanceInMips: 20
+    init:
+        IsHalted false
+
+nvic0: IRQControllers.NVIC @ sysbus new Bus.BusPointRegistration {
+        address: 0xe000e000;
+        cpu: cpu0
+    }
+    systickFrequency: 125000000
+    -> cpu0@0
+
+nvic1: IRQControllers.NVIC @ sysbus new Bus.BusPointRegistration {
+    address: 0xe000e000;
+    cpu: cpu1
+    }
+    systickFrequency: 125000000
+    -> cpu1@0
+
+uart0: UART.RP2040Uart @ sysbus 0x40034000
+    address: 0x40034000
+
+uart0:
+    IRQ ->nvic0@20
+    DMATransmitRequest -> dma@20
+    DMAReceiveRequest -> dma@21
+
+// Tag PIO for now to allow firmware to boot without full PIO implementation if not available in standard renode
+sysbus:
+    init:
+        Tag <0x50200000 0x1000> "PIO0"
+        Tag <0x50300000 0x1000> "PIO1"
+
+// raspberrypi,rp2040 overlay
+
+resets: Resets.RP2040Resets @ sysbus 0x4000c000
+    address: 0x4000c000
+
+sysbus:
+    init:
+        Tag <0x40024004 4> "XOSC_STATUS" 0xFFFFFFFF
+        Tag <0x40028000 4> "PLL_SYS_CS" 0xFFFFFFFF
+        Tag <0x4002C000 4> "PLL_USB_CS" 0xFFFFFFFF
+// cortex-m overlay
+
+dwt: Miscellaneous.DWT @ sysbus 0xE0001000
+    // according to 4.7.2 RP2040 Datasheet is 1MHz
+    frequency: 1000000
+
+timer: Timers.RP2040Timer @  sysbus 0x40054000
+    address: 0x40054000
+    IRQ0 -> nvic0@0
+    IRQ1 -> nvic0@1
+    IRQ2 -> nvic0@2
+    IRQ3 -> nvic0@3
+
+clocks: Miscellaneous.RP2040Clocks @ sysbus 0x40008000 {
+    address: 0x40008000;
+    gpio: gpio
+}
+
+clocks:
+    IRQ -> nvic0@17
+
+gpio: GPIOPort.RP2040GPIO @ sysbus 0x40014000 {
+    numberOfPins: 30;
+    numberOfCores: 2;
+    address: 0x40014000
+}
+
+gpio:
+    IRQ0 -> nvic0@13
+    IRQ1 -> nvic1@13
+
+
+gpio_qspi: GPIOPort.RP2040GPIO @ sysbus 0x40018000 {
+    numberOfPins: 6;
+    numberOfCores: 2;
+    address: 0x40018000
+}
+
+sio: Miscellaneous.RP2040SIO @ sysbus 0xd0000000 {
+    gpio: gpio;
+    gpioQspi: gpio_qspi;
+    address: 0xd0000000
+}
+sio:
+    Core0IRQ -> nvic0@15
+    Core1IRQ -> nvic1@16
+
+pads: GPIOPort.RP2040Pads @ sysbus 0x4001c000 {
+    gpio: gpio;
+    address: 0x4001c000
+}
+
+adc: Analog.RP2040ADC @ sysbus 0x4004c000 {
+    address: 0x4004c000;
+    clocks: clocks;
+    pads: pads
+}
+adc:
+    IRQ -> nvic0@22
+    DMARequest -> dma@36
+
+dma: DMA.RPDMA @ sysbus 0x50000000 {
+    numberOfChannels: 12;
+    address: 0x50000000
+}
+
+dma:
+    IRQ0 -> nvic0@11
+    IRQ1 -> nvic0@12
+
+watchdog: Timers.RP2040Watchdog @ sysbus 0x40058000 {
+    address: 0x40058000;
+    clocks: clocks
+}
+
+rtc: Timers.RP2040RTC @ sysbus 0x4005c000 {
+    address: 0x4005c000
+}
+
+rtc:
+    IRQ -> nvic0@25
+
+psm: Miscellaneous.PSM @ sysbus 0x40010000 {
+    address: 0x40010000
+}
+
+pwm: PWM.RP2040PWM @ sysbus 0x40050000 {
+    address: 0x40050000
+}
+
+pwm:
+    IRQ -> nvic0@4

--- a/test/renode/tests/cli_tests.robot
+++ b/test/renode/tests/cli_tests.robot
@@ -1,0 +1,29 @@
+*** Settings ***
+Suite Setup     Setup
+Suite Teardown  Teardown
+Resource        ${RENODEKEYWORDS}
+
+*** Variables ***
+${RESC}         ${CURDIR}/../xiao_rp2040.resc
+${UART}         sysbus.uart0
+
+*** Test Cases ***
+Should Boot And Show Welcome Message
+    Wait For Line On Uart     xDuinoRails_MM starting...    timeout=10
+
+Should Respond To Help Command
+    Write Line To Uart        ?
+    Wait For Line On Uart     Available commands:           timeout=5
+
+Should Read All CVs
+    Write Line To Uart        cv
+    Wait For Line On Uart     CV 1:                         timeout=5
+    Wait For Line On Uart     CV 250:                       timeout=5
+
+*** Keywords ***
+Setup
+    Start Emulation
+    Execute Script          ${RESC}
+
+Teardown
+    Reset Emulation

--- a/test/renode/tests/cli_tests.robot
+++ b/test/renode/tests/cli_tests.robot
@@ -22,8 +22,9 @@ Should Read All CVs
 
 *** Keywords ***
 Setup
-    Start Emulation
-    Execute Script          ${RESC}
+    Execute Command         include @${RESC}
+    Create Terminal Tester  ${UART}
+    Execute Command         emulation Start
 
 Teardown
-    Reset Emulation
+    Execute Command         emulation Stop

--- a/test/renode/xiao_rp2040.resc
+++ b/test/renode/xiao_rp2040.resc
@@ -1,0 +1,20 @@
+$bin?=@../../.pio/build/seeed_xiao_rp2040_renode/firmware.elf
+
+using sysbus
+mach create "xiao-rp2040"
+machine LoadPlatformDescription @boards/seeed_xiao_rp2040.repl
+
+showAnalyzer sysbus.uart0
+
+sysbus LoadELF $bin
+
+# Set Vector Table Offset for RP2040
+cpu0 VectorTableOffset 0x10000000
+
+macro reset
+"""
+    sysbus LoadELF $bin
+    cpu0 VectorTableOffset 0x10000000
+"""
+
+runMacro $reset


### PR DESCRIPTION
I have integrated a Renode simulation environment for the RP2040-based xDuinoRails_MM project. This allows for automated verification of the decoder's firmware, particularly the Serial Console and CLI interaction, within the CI/CD pipeline and via a local script. 

The integration includes:
- **Hardware Modeling:** REPL files for the RP2040 core and XIAO board, mapped to the project's specific pinout.
- **Automated Testing:** A Robot Framework test suite that verifies the firmware's boot sequence and command responsiveness.
- **CI/CD Integration:** A new job in the GitHub Actions workflow that executes the simulation tests on every push.
- **Developer Tooling:** A `run_renode_tests.sh` script that simplifies running the simulation locally by handling the portable Renode installation.
- **Documentation:** `ROADMAP_RENODE.md` and `RENODE_GAPS.md` to guide future improvements and clarify current simulation boundaries.

Fixes #267

---
*PR created automatically by Jules for task [9895791398295963723](https://jules.google.com/task/9895791398295963723) started by @chatelao*