### PR TITLE
Allow CLI short forms

### DIFF
--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -16,7 +16,10 @@ void test_cv_manager_reset_8(void);
 void test_motor_speed_curve(void);
 void test_logging(void);
 void test_logger_categories(void);
+void test_pwm_freq_logging(void);
+void test_cv_motor_type_reboot(void);
 void test_serial_console(void);
+void test_serial_console_short_forms(void);
 void test_serial_console_cv_readout(void);
 void test_cv_manager_print_all(void);
 void test_motor_kickstart_bemf_disabled(void);
@@ -521,6 +524,55 @@ void test_serial_console(void) {
   TEST_ASSERT_FALSE(protocol.getFunctionState(1));
 }
 
+void test_serial_console_short_forms(void) {
+  CvManagerMock   cvManager;
+  ProtocolHandler protocol(0);
+  protocol.setAddress(1);
+  SerialConsole console(&cvManager, &protocol);
+
+  cvManager.setCv(CV_DEBUG_ENABLE, 1);
+  logger.begin(&cvManager);
+
+  // Test "cv8 8"
+  Serial.pushInput("cv8 8\n");
+  console.loop();
+  TEST_ASSERT_EQUAL(8, cvManager.getCv(8));
+
+  // Test "s10"
+  Serial.pushInput("s10\n");
+  console.loop();
+  TEST_ASSERT_EQUAL(10, protocol.getTargetSpeed());
+
+  // Test "df"
+  Serial.pushInput("df\n");
+  console.loop();
+  TEST_ASSERT_EQUAL(MM2DirectionState_Forward, protocol.getTargetDirection());
+
+  // Test "db"
+  Serial.pushInput("db\n");
+  console.loop();
+  TEST_ASSERT_EQUAL(MM2DirectionState_Backward, protocol.getTargetDirection());
+
+  // Test "f1"
+  Serial.pushInput("f1\n");
+  console.loop();
+  TEST_ASSERT_TRUE(protocol.getFunctionState(1));
+
+  // Test "f0"
+  Serial.pushInput("f0\n");
+  console.loop();
+  TEST_ASSERT_FALSE(protocol.getFunctionState(1));
+
+  // Test "lh" (High speed toggle)
+  bool initialHighSpeed = logger.isHighSpeedEnabled();
+  Serial.pushInput("lh\n");
+  console.loop();
+  TEST_ASSERT_EQUAL(!initialHighSpeed, logger.isHighSpeedEnabled());
+  // Toggle back to restore state for other tests
+  Serial.pushInput("lh\n");
+  console.loop();
+}
+
 void test_serial_console_cv_readout(void) {
   CvManagerMock   cvManager;
   ProtocolHandler protocol(0);
@@ -761,9 +813,10 @@ void test_serial_console_help(void) {
   for (const auto &line : Serial.logLines) {
     if (line.find("--- xDuinoRails CLI Help ---") != std::string::npos)
       foundHelpHeader = true;
-    if (line.find("cv <num> <val> : Set CV value") != std::string::npos)
+    if (line.find("cv <num> <val> : Set CV value") != std::string::npos ||
+        line.find("cv <num> <val> : Set CV value (short form: cv<num> <val>)") != std::string::npos)
       foundCvCmd = true;
-    if (line.find("s <speed>      : Set speed (0-14)") != std::string::npos)
+    if (line.find("s <speed>      : Set speed") != std::string::npos)
       foundSpeedCmd = true;
     if (line.find("h/?            : Show this help") != std::string::npos)
       foundHelpCmd = true;
@@ -910,6 +963,7 @@ int main(int argc, char **argv) {
   RUN_TEST(test_pwm_freq_logging);
   RUN_TEST(test_cv_motor_type_reboot);
   RUN_TEST(test_serial_console);
+  RUN_TEST(test_serial_console_short_forms);
   RUN_TEST(test_serial_console_cv_readout);
   RUN_TEST(test_cv_manager_print_all);
   RUN_TEST(test_motor_kickstart_bemf_disabled);

--- a/xDuinoRails_MM/SerialConsole.cpp
+++ b/xDuinoRails_MM/SerialConsole.cpp
@@ -37,11 +37,13 @@ void SerialConsole::parseCommand(char *line) {
   } else if (sscanf(line, "s %d", &val1) == 1) {
     protocol->setTargetSpeed(val1);
     logger.printf("Serial: Speed set to %d\n", val1);
-  } else if (line[0] == 'd' && line[1] == ' ') {
-    if (line[2] == 'f') {
+  } else if (line[0] == 'd') {
+    char *p = &line[1];
+    while (*p == ' ') p++;
+    if (*p == 'f') {
       protocol->setTargetDirection(MM2DirectionState_Forward);
       logger.println("Serial: Direction Forward");
-    } else if (line[2] == 'b') {
+    } else if (*p == 'b') {
       protocol->setTargetDirection(MM2DirectionState_Backward);
       logger.println("Serial: Direction Backward");
     }
@@ -50,8 +52,10 @@ void SerialConsole::parseCommand(char *line) {
     protocol->setFunctionState(1, val1 > 0);
     logger.printf("Serial: Function 1 set to %d\n", val1 > 0);
   } else if (line[0] == 'L' || line[0] == 'l') {
-    if (line[1] == ' ' && line[2] != '\0') {
-      char sub = line[2];
+    char *p = &line[1];
+    while (*p == ' ') p++;
+    if (*p != '\0') {
+      char sub = *p;
       if (sub == 'p') {
         logger.toggleCategory(LogCategory::Protocol);
         Serial.print("Serial: Protocol Logging ");
@@ -85,12 +89,12 @@ void SerialConsole::parseCommand(char *line) {
 
 void SerialConsole::printHelp() {
   Serial.println("--- xDuinoRails CLI Help ---");
-  Serial.println("cv <num> <val> : Set CV value");
+  Serial.println("cv <num> <val> : Set CV value (short form: cv<num> <val>)");
   Serial.println("cv             : Print all CV values");
-  Serial.println("s <speed>      : Set speed (0-14)");
-  Serial.println("d f/b          : Set direction (f: forward, b: backward)");
-  Serial.println("f <0/1>        : Set Function 1 (0: off, 1: on)");
-  Serial.println("L [p/w/c/b/h]  : Toggle logging (p: protocol, w: pwm, c: cv, b: bemf, h: highspeed)");
+  Serial.println("s <speed>      : Set speed 0-14 (short form: s<speed>)");
+  Serial.println("d f/b          : Set direction (f: forward, b: backward; short form: df/db)");
+  Serial.println("f <0/1>        : Set Function 1 (0: off, 1: on; short form: f0/f1)");
+  Serial.println("L [p/w/c/b/h]  : Toggle logging (p: protocol, w: pwm, c: cv, b: bemf, h: highspeed; short form: Lp/Lw...)");
   Serial.println("h/?            : Show this help");
   Serial.println("----------------------------");
 }


### PR DESCRIPTION
Allow CLI short forms too, e.g. "cv8 8" or "lh" or "s10".
This was achieved by:
- Modifying `SerialConsole::parseCommand` to skip optional spaces for `d`, `f`, and `l/L` commands.
- Leveraging `sscanf` behavior for `cv`, `s`, and `f` commands which already supports optional spaces.
- Updating CLI help text to document short forms.
- Adding `test_serial_console_short_forms` to native tests.
- Fixing existing tests that were sensitive to help text changes or logger state.

Fixes #271

---
*PR created automatically by Jules for task [6285927544040154771](https://jules.google.com/task/6285927544040154771) started by @chatelao*