### PR TITLE
Implement median-of-three filter in readBEMF

### DIFF
--- a/test/mocks/Arduino.h
+++ b/test/mocks/Arduino.h
@@ -10,6 +10,7 @@
 extern std::map<uint8_t, int> analog_write_values;
 extern std::map<uint8_t, int> digital_write_values;
 extern std::map<uint8_t, int> analog_read_values;
+extern std::map<uint8_t, std::deque<int>> analog_read_sequences;
 extern int                    last_pwm_freq;
 extern std::map<uint8_t, int> last_esp32_pwm_freq;
 

--- a/test/test_native/Arduino.cpp
+++ b/test/test_native/Arduino.cpp
@@ -3,6 +3,7 @@
 std::map<uint8_t, int> analog_write_values;
 std::map<uint8_t, int> digital_write_values;
 std::map<uint8_t, int> analog_read_values;
+std::map<uint8_t, std::deque<int>> analog_read_sequences;
 int                    last_pwm_freq = 0;
 std::map<uint8_t, int> last_esp32_pwm_freq;
 
@@ -15,6 +16,11 @@ void pinMode(uint8_t pin, uint8_t mode) {
 void digitalWrite(uint8_t pin, uint8_t val) { digital_write_values[pin] = val; }
 
 int analogRead(uint8_t pin) {
+  if (analog_read_sequences.count(pin) && !analog_read_sequences[pin].empty()) {
+    int val = analog_read_sequences[pin].front();
+    analog_read_sequences[pin].pop_front();
+    return val;
+  }
   if (analog_read_values.count(pin)) {
     return analog_read_values[pin];
   }
@@ -51,6 +57,7 @@ void reset_arduino_mock() {
   analog_write_values.clear();
   digital_write_values.clear();
   analog_read_values.clear();
+  analog_read_sequences.clear();
   last_pwm_freq = 0;
   last_esp32_pwm_freq.clear();
   current_millis = 0;

--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -46,6 +46,7 @@ void test_bemf_collector_gap_persistent_failure(void);
 void test_bemf_collector_gap_with_integral_filtered(void);
 void test_bemf_stability_integral_clamping(void);
 void test_read_bemf_shutdown_toggling(void);
+void test_read_bemf_internal_median(void);
 
 // Mock implementation for RP2040 reboot
 bool   reboot_called = false;
@@ -993,5 +994,6 @@ int main(int argc, char **argv) {
   RUN_TEST(test_bemf_collector_gap_with_integral_filtered);
   RUN_TEST(test_bemf_stability_integral_clamping);
   RUN_TEST(test_read_bemf_shutdown_toggling);
+  RUN_TEST(test_read_bemf_internal_median);
   return UNITY_END();
 }

--- a/test/test_native/test_read_bemf_median.cpp
+++ b/test/test_native/test_read_bemf_median.cpp
@@ -1,0 +1,46 @@
+#include "CvManagerMock.h"
+#include "MotorControl.h"
+#include "Arduino.h"
+#include <unity.h>
+#include <deque>
+#include <map>
+
+void test_read_bemf_internal_median(void) {
+  CvManagerMock cvManager;
+  // BEMF pins: 2 and 3
+  MotorControl motor(cvManager, 10, 11, 2, 3, 12);
+  motor.setup();
+
+  // Test Case 1: Median is the middle value
+  // Samples will be |200-0| = 200, |100-0| = 100, |300-0| = 300
+  // Median of {200, 100, 300} is 200
+  analog_read_sequences[2] = {200, 100, 300};
+  analog_read_sequences[3] = {0, 0, 0};
+
+  int result = motor.readBEMF();
+  TEST_ASSERT_EQUAL(200, result);
+
+  // Test Case 2: Median with different pins
+  // Samples: |0-500| = 500, |0-100| = 100, |0-400| = 400
+  // Median of {500, 100, 400} is 400
+  analog_read_sequences[2] = {0, 0, 0};
+  analog_read_sequences[3] = {500, 100, 400};
+
+  result = motor.readBEMF();
+  TEST_ASSERT_EQUAL(400, result);
+
+  // Test Case 3: All same
+  analog_read_sequences[2] = {150, 150, 150};
+  analog_read_sequences[3] = {0, 0, 0};
+
+  result = motor.readBEMF();
+  TEST_ASSERT_EQUAL(150, result);
+
+  // Test Case 4: Two same
+  // {100, 200, 100} -> Median 100
+  analog_read_sequences[2] = {100, 200, 100};
+  analog_read_sequences[3] = {0, 0, 0};
+
+  result = motor.readBEMF();
+  TEST_ASSERT_EQUAL(100, result);
+}

--- a/xDuinoRails_MM/MotorControl.cpp
+++ b/xDuinoRails_MM/MotorControl.cpp
@@ -363,8 +363,14 @@ int MotorControl::readBEMF() {
   digitalWrite(pinB_priv, LOW);
 
   delayMicroseconds(500);
-  int valA = analogRead(bemfA_priv);
-  int valB = analogRead(bemfB_priv);
+
+  int samples[3];
+  for (int i = 0; i < 3; i++) {
+    int valA   = analogRead(bemfA_priv);
+    int valB   = analogRead(bemfB_priv);
+    samples[i] = (valA > valB) ? (valA - valB) : (valB - valA);
+    if (i < 2) delayMicroseconds(10);
+  }
 
   if (shutPin_priv != -1) {
     digitalWrite(shutPin_priv, LOW); // Re-enable H-bridge
@@ -373,5 +379,11 @@ int MotorControl::readBEMF() {
   // Since we touched the pins, invalidate the write cache
   lastWrittenPwm = -1;
 
-  return (valA > valB) ? (valA - valB) : (valB - valA);
+  // Median-of-3
+  int a = samples[0];
+  int b = samples[1];
+  int c = samples[2];
+  if ((a <= b && b <= c) || (c <= b && b <= a)) return b;
+  if ((b <= a && a <= c) || (c <= a && a <= b)) return a;
+  return c;
 }


### PR DESCRIPTION
This change implements a median-of-three filter directly within the `readBEMF()` method of the `MotorControl` class. By taking three rapid samples with a microsecond-scale delay (10µs) and selecting the median, the system becomes more resilient to transient noise and spikes during the BEMF measurement window. 

The test infrastructure was also updated to support this new behavior by allowing `analogRead` to return a sequence of predefined values. A new unit test `test_read_bemf_internal_median` was added to ensure the median logic is correctly implemented.

Fixes #273

---
*PR created automatically by Jules for task [18134171048645807693](https://jules.google.com/task/18134171048645807693) started by @chatelao*