### PR TITLE
Allow running the decoder by open or closed loop with compile flags

### DIFF
--- a/test/test_native/test_cv49_verification.cpp
+++ b/test/test_native/test_cv49_verification.cpp
@@ -92,3 +92,28 @@ void test_cv49_zero_with_direction_change(void) {
     TEST_ASSERT_FALSE(motor.isKickstarting());
     TEST_ASSERT_EQUAL(531, analog_write_values[11]);
 }
+
+void test_is_bemf_enabled_compile_flags(void) {
+    CvManagerMock cvManager;
+    MotorControl motor(cvManager, 10, 11, 2, 3, 12);
+    motor.setup();
+
+    // Check behavior depending on what macros are defined during build
+#if defined(FORCE_OPEN_LOOP) || defined(OPEN_LOOP)
+    cvManager.setCv(CV_BEMF_CONFIG, 1);
+    TEST_ASSERT_FALSE(motor.isBemfEnabled());
+    cvManager.setCv(CV_BEMF_CONFIG, 0);
+    TEST_ASSERT_FALSE(motor.isBemfEnabled());
+#elif defined(FORCE_CLOSED_LOOP) || defined(CLOSED_LOOP)
+    cvManager.setCv(CV_BEMF_CONFIG, 1);
+    TEST_ASSERT_TRUE(motor.isBemfEnabled());
+    cvManager.setCv(CV_BEMF_CONFIG, 0);
+    TEST_ASSERT_TRUE(motor.isBemfEnabled());
+#else
+    // Default fallback case (reading from CV 49)
+    cvManager.setCv(CV_BEMF_CONFIG, 1);
+    TEST_ASSERT_TRUE(motor.isBemfEnabled());
+    cvManager.setCv(CV_BEMF_CONFIG, 0);
+    TEST_ASSERT_FALSE(motor.isBemfEnabled());
+#endif
+}

--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -38,6 +38,7 @@ void test_repro_kickstart_only(void);
 void test_repro_kickstart_only_with_vstart_zero(void);
 void test_cv49_zero_only_kickstart_works(void);
 void test_cv49_zero_with_direction_change(void);
+void test_is_bemf_enabled_compile_flags(void);
 void test_high_speed_logging(void);
 void test_pwm_frequency_defaults(void);
 void test_pwm_frequency_override(void);
@@ -984,6 +985,7 @@ int main(int argc, char **argv) {
   RUN_TEST(test_repro_kickstart_only_with_vstart_zero);
   RUN_TEST(test_cv49_zero_only_kickstart_works);
   RUN_TEST(test_cv49_zero_with_direction_change);
+  RUN_TEST(test_is_bemf_enabled_compile_flags);
   RUN_TEST(test_high_speed_logging);
   RUN_TEST(test_pwm_frequency_defaults);
   RUN_TEST(test_pwm_frequency_override);

--- a/xDuinoRails_MM/MotorControl.cpp
+++ b/xDuinoRails_MM/MotorControl.cpp
@@ -186,7 +186,7 @@ void MotorControl::update(int pwm, MM2DirectionState dir) {
       // Ensure target PWM is applied immediately after kickstart ends
       writeMotorHardware(targetPwm, currDirection);
     } else {
-      bool bemfEnabled = (cvManager.getCv(CV_BEMF_CONFIG) & 0x01);
+      bool bemfEnabled = isBemfEnabled();
       if (bemfEnabled && (now - lastBemfMeasure > BEMF_SAMPLE_INT)) {
         int currentBEMF = readBEMF();
         lastBemfMeasure = now;
@@ -219,7 +219,7 @@ void MotorControl::update(int pwm, MM2DirectionState dir) {
     } else {
       int finalPwm = targetPwm;
 
-      bool bemfEnabled = (cvManager.getCv(CV_BEMF_CONFIG) & 0x01);
+      bool bemfEnabled = isBemfEnabled();
       if (bemfEnabled && targetPwm > 0) {
         if (now - lastBemfMeasure > BEMF_SAMPLE_INT) {
           int currentBEMF = readBEMF();
@@ -304,6 +304,16 @@ void MotorControl::update(int pwm, MM2DirectionState dir) {
 }
 
 void MotorControl::stop() { update(0, currDirection); }
+
+bool MotorControl::isBemfEnabled() {
+#if defined(FORCE_OPEN_LOOP) || defined(OPEN_LOOP)
+  return false;
+#elif defined(FORCE_CLOSED_LOOP) || defined(CLOSED_LOOP)
+  return true;
+#else
+  return (cvManager.getCv(CV_BEMF_CONFIG) & 0x01) != 0;
+#endif
+}
 
 bool MotorControl::isKickstarting() { return isKickstarting_priv; }
 

--- a/xDuinoRails_MM/MotorControl.h
+++ b/xDuinoRails_MM/MotorControl.h
@@ -19,6 +19,9 @@ public:
   MM2DirectionState getCurrentDirection();
   int               readBEMF();
 
+public:
+  bool isBemfEnabled();
+
 private:
   void update(int targetPwm, MM2DirectionState targetDir);
   void writeMotorHardware(int pwm, MM2DirectionState dir);


### PR DESCRIPTION
Allow to run the decoder by open or closed loop with compile-time preprocessor flags FORCE_OPEN_LOOP, OPEN_LOOP, FORCE_CLOSED_LOOP, or CLOSED_LOOP. Otherwise, fallback to reading CV 49 bit 0. Add comprehensive native unit tests.

Fixes #282

---
*PR created automatically by Jules for task [8562176600409582152](https://jules.google.com/task/8562176600409582152) started by @chatelao*