### PR TITLE
Disable BEMF (CV 49) by default and verify open-loop operation

### DIFF
--- a/test/mocks/CvManagerMock.h
+++ b/test/mocks/CvManagerMock.h
@@ -22,7 +22,7 @@ public:
     cvStore[CV_CONFIGURATION]     = 6;
     cvStore[CV_FRONT_LIGHT_F0F]   = 1;
     cvStore[CV_REAR_LIGHT_F0R]    = 2;
-    cvStore[CV_BEMF_CONFIG]       = 1;
+    cvStore[CV_BEMF_CONFIG]       = 0;
     cvStore[CV_EXT_ID_HIGH]       = 1;
     cvStore[CV_EXT_ID_LOW]        = 10;
     cvStore[CV_MOTOR_TYPE]        = 0;

--- a/test/test_native/test_cv49_verification.cpp
+++ b/test/test_native/test_cv49_verification.cpp
@@ -92,3 +92,43 @@ void test_cv49_zero_with_direction_change(void) {
     TEST_ASSERT_FALSE(motor.isKickstarting());
     TEST_ASSERT_EQUAL(531, analog_write_values[11]);
 }
+
+void test_cv49_disabled_by_default_open_loop_no_pid(void) {
+    CvManagerMock cvManager;
+    // BEMF config is 0 by default now.
+    cvManager.setCv(CV_START_VOLTAGE, 10);
+    cvManager.setCv(CV_MEDIUM_SPEED, 0);
+    cvManager.setCv(CV_MAXIMUM_SPEED, 0);
+    cvManager.setCv(CV_MOTOR_TYPE, 0);
+
+    MotorControl motor(cvManager, 10, 11, 2, 3, 12);
+    motor.setup();
+
+    // Verify CV 49 is indeed 0 by default
+    TEST_ASSERT_EQUAL(0, cvManager.getCv(CV_BEMF_CONFIG));
+
+    // Set speed step 7
+    motor.setSpeed(7, MM2DirectionState_Forward);
+
+    // Pass the kickstart period (100ms for type 0)
+    advance_millis(150);
+    motor.setSpeed(7, MM2DirectionState_Forward);
+
+    // Hardware PWM should be 531 (Vmid)
+    TEST_ASSERT_EQUAL(531, analog_write_values[10]);
+
+    // Now, even if we inject high/low BEMF values via analog reads,
+    // since BEMF is disabled, the control loop should NOT perform BEMF readings
+    // and there should be no adjustments.
+    extern std::map<uint8_t, std::deque<int>> analog_read_sequences;
+    analog_read_sequences[2] = {1000, 1000, 1000};
+    analog_read_sequences[3] = {0, 0, 0};
+
+    advance_millis(20);
+    motor.setSpeed(7, MM2DirectionState_Forward);
+
+    // The output should still be exactly 531, and analog reads on BEMF pins 2 and 3 should not have been consumed
+    TEST_ASSERT_EQUAL(531, analog_write_values[10]);
+    // The sequence for Pin 2 should still contain 3 items because no analogRead was called!
+    TEST_ASSERT_EQUAL(3, analog_read_sequences[2].size());
+}

--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -38,6 +38,7 @@ void test_repro_kickstart_only(void);
 void test_repro_kickstart_only_with_vstart_zero(void);
 void test_cv49_zero_only_kickstart_works(void);
 void test_cv49_zero_with_direction_change(void);
+void test_cv49_disabled_by_default_open_loop_no_pid(void);
 void test_high_speed_logging(void);
 void test_pwm_frequency_defaults(void);
 void test_pwm_frequency_override(void);
@@ -82,6 +83,7 @@ void test_cv_manager_defaults(void) {
   TEST_ASSERT_EQUAL(2, cvManager.getCv(CV_REAR_LIGHT_F0R));
   TEST_ASSERT_EQUAL(1, cvManager.getCv(CV_EXT_ID_HIGH));
   TEST_ASSERT_EQUAL(10, cvManager.getCv(CV_EXT_ID_LOW));
+  TEST_ASSERT_EQUAL(0, cvManager.getCv(CV_BEMF_CONFIG));
   TEST_ASSERT_EQUAL(16, cvManager.getCv(CV_BEMF_K));
   TEST_ASSERT_EQUAL(12, cvManager.getCv(CV_BEMF_I));
   TEST_ASSERT_EQUAL(1, cvManager.getCv(CV_DEBUG_ENABLE));
@@ -984,6 +986,7 @@ int main(int argc, char **argv) {
   RUN_TEST(test_repro_kickstart_only_with_vstart_zero);
   RUN_TEST(test_cv49_zero_only_kickstart_works);
   RUN_TEST(test_cv49_zero_with_direction_change);
+  RUN_TEST(test_cv49_disabled_by_default_open_loop_no_pid);
   RUN_TEST(test_high_speed_logging);
   RUN_TEST(test_pwm_frequency_defaults);
   RUN_TEST(test_pwm_frequency_override);

--- a/xDuinoRails_MM/CvManager.cpp
+++ b/xDuinoRails_MM/CvManager.cpp
@@ -95,7 +95,7 @@ void CvManager::initCv() {
     EEPROM.write(CV_CONFIGURATION, 6);
     EEPROM.write(CV_FRONT_LIGHT_F0F, 1);
     EEPROM.write(CV_REAR_LIGHT_F0R, 2);
-    EEPROM.write(CV_BEMF_CONFIG, 1);
+    EEPROM.write(CV_BEMF_CONFIG, 0);
     EEPROM.write(CV_BEMF_K, 16);
     EEPROM.write(CV_BEMF_I, 12);
     EEPROM.write(CV_MOTOR_TYPE, 0);


### PR DESCRIPTION
Disables BEMF support (CV 49) by default, ensuring that the motor operates in a clean open-loop mode by default where both PID controller and feedback sampling are bypassed. Includes a comprehensive unit test suite verification.

Fixes #283

---
*PR created automatically by Jules for task [15403068374159531156](https://jules.google.com/task/15403068374159531156) started by @chatelao*