### PR TITLE
Add checks and tests for pure open-loop compiled code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,9 @@ jobs:
         run: pip install --upgrade platformio
 
       - name: Test PlatformIO Project
-        run: pio test -e native --without-uploading
+        run: |
+          pio test -e native --without-uploading
+          pio test -e native_open_loop --without-uploading
 
       - name: Build firmware
         run: pio run -e seeed_xiao_rp2040 -e seeed_xiao_esp32c6

--- a/platformio.ini
+++ b/platformio.ini
@@ -31,3 +31,14 @@ build_src_filter = +<CvManager.cpp> +<MotorControl.cpp> +<LightsControl.cpp> +<P
 test_ignore =
   test_protocol_handler
   test_simple
+
+[env:native_open_loop]
+platform = native
+test_framework = unity
+build_flags = -I test/mocks -DARDUINO_ARCH_RP2040 -DOPEN_LOOP
+lib_ignore = MaerklinMotorola
+test_build_src = true
+build_src_filter = +<CvManager.cpp> +<MotorControl.cpp> +<LightsControl.cpp> +<ProtocolHandler.cpp> +<CvProgrammer.cpp> +<Logger.cpp> +<SerialConsole.cpp> +<DebugLeds.cpp>
+test_ignore =
+  test_protocol_handler
+  test_simple

--- a/test/test_native/test_bemf_glitch.cpp
+++ b/test/test_native/test_bemf_glitch.cpp
@@ -9,6 +9,7 @@ extern std::map<uint8_t, int> analog_write_values;
 extern std::map<uint8_t, int> analog_read_values;
 extern void advance_millis(unsigned long ms);
 
+#if !defined(OPEN_LOOP) && !defined(FORCE_OPEN_LOOP)
 void test_bemf_collector_gap_glitch(void) {
   CvManagerMock cvManager;
   cvManager.setCv(CV_START_VOLTAGE, 10);  // PWM 40
@@ -52,3 +53,4 @@ void test_bemf_collector_gap_glitch(void) {
 
   TEST_ASSERT_EQUAL(531, analog_write_values[10]);
 }
+#endif

--- a/test/test_native/test_bemf_stability.cpp
+++ b/test/test_native/test_bemf_stability.cpp
@@ -7,6 +7,7 @@ extern std::map<uint8_t, int> analog_write_values;
 extern std::map<uint8_t, int> analog_read_values;
 extern void advance_millis(unsigned long ms);
 
+#if !defined(OPEN_LOOP) && !defined(FORCE_OPEN_LOOP)
 /**
  * Test to verify the stability of the PI controller and the effectiveness of the reduced integral windup limit.
  */
@@ -73,6 +74,7 @@ void test_bemf_stability_integral_clamping(void) {
   motor.setSpeed(7, MM2DirectionState_Forward);
   TEST_ASSERT_EQUAL(0, analog_write_values[10]);
 }
+#endif
 
 /**
  * Test to verify that readBEMF properly toggles the shutdown pin.

--- a/test/test_native/test_cv49_verification.cpp
+++ b/test/test_native/test_cv49_verification.cpp
@@ -117,3 +117,74 @@ void test_is_bemf_enabled_compile_flags(void) {
     TEST_ASSERT_FALSE(motor.isBemfEnabled());
 #endif
 }
+
+#if defined(OPEN_LOOP) || defined(FORCE_OPEN_LOOP)
+void test_open_loop_kickstart_ignores_high_bemf(void) {
+    CvManagerMock cvManager;
+    cvManager.setCv(CV_START_VOLTAGE, 10);
+    cvManager.setCv(CV_MOTOR_TYPE, 0); // standard DC: kickstart = 100ms
+    cvManager.setCv(CV_BEMF_CONFIG, 1); // Enable BEMF via CV
+
+    MotorControl motor(cvManager, 10, 11, 2, 3, 12);
+    motor.setup();
+
+    // Start kickstart
+    motor.setSpeed(7, MM2DirectionState_Forward);
+    TEST_ASSERT_TRUE(motor.isKickstarting());
+
+    // Inject high BEMF
+    analog_read_values[2] = 500;
+    analog_read_values[3] = 0;
+
+    // Call update, kickstart must still be active because compiles as OPEN_LOOP
+    advance_millis(20);
+    motor.setSpeed(7, MM2DirectionState_Forward);
+    TEST_ASSERT_TRUE(motor.isKickstarting());
+
+    // Timeout
+    advance_millis(100);
+    motor.setSpeed(7, MM2DirectionState_Forward);
+    TEST_ASSERT_FALSE(motor.isKickstarting());
+}
+
+void test_open_loop_adjustments_always_zero(void) {
+    CvManagerMock cvManager;
+    cvManager.setCv(CV_START_VOLTAGE, 10);
+    cvManager.setCv(CV_MOTOR_TYPE, 0);
+    cvManager.setCv(CV_BEMF_CONFIG, 1); // Enable BEMF via CV
+    cvManager.setCv(CV_BEMF_K, 64);
+    cvManager.setCv(CV_BEMF_I, 64);
+
+    MotorControl motor(cvManager, 10, 11, 2, 3, 12);
+    motor.setup();
+
+    // Set speed step 7 (targetPwm = 531)
+    motor.setSpeed(7, MM2DirectionState_Forward);
+    advance_millis(150); // Pass kickstart
+
+    // Inject massive BEMF error (e.g. stalled motor)
+    analog_read_values[2] = 0;
+    analog_read_values[3] = 0;
+
+    // Under open loop, this error shouldn't be processed and adjustment must be 0
+    advance_millis(20);
+    motor.setSpeed(7, MM2DirectionState_Forward);
+
+    // It should be exactly 531 (no PI control adjustment added)
+    TEST_ASSERT_EQUAL(531, analog_write_values[10]);
+}
+
+void test_open_loop_cv_ignored_in_loop_type(void) {
+    CvManagerMock cvManager;
+    MotorControl motor(cvManager, 10, 11, 2, 3, 12);
+    motor.setup();
+
+    // Try setting BEMF_CONFIG to 1, should still return false
+    cvManager.setCv(CV_BEMF_CONFIG, 1);
+    TEST_ASSERT_FALSE(motor.isBemfEnabled());
+
+    // Try setting BEMF_CONFIG to 0, should still return false
+    cvManager.setCv(CV_BEMF_CONFIG, 0);
+    TEST_ASSERT_FALSE(motor.isBemfEnabled());
+}
+#endif

--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -23,29 +23,44 @@ void test_serial_console_short_forms(void);
 void test_serial_console_cv_readout(void);
 void test_cv_manager_print_all(void);
 void test_motor_kickstart_bemf_disabled(void);
+#if !defined(OPEN_LOOP) && !defined(FORCE_OPEN_LOOP)
 void test_motor_kickstart_bemf_enabled(void);
+#endif
 void test_motor_pwm_mapping_detailed(void);
 void test_motor_pwm_mapping_new_defaults(void);
 void test_debug_leds_heartbeat(void);
+#if !defined(OPEN_LOOP) && !defined(FORCE_OPEN_LOOP)
 void test_motor_bemf_pi_control(void);
+#endif
 void test_serial_console_logging_toggle(void);
 void test_serial_console_help(void);
 void test_repro_watchdog_stop_no_kickstart(void);
 void test_repro_start_backward_kickstart_wrong_dir(void);
+#if !defined(OPEN_LOOP) && !defined(FORCE_OPEN_LOOP)
 void test_repro_bemf_disabled_leftover_adjustment(void);
+#endif
 void test_repro_direction_change_kickstart(void);
 void test_repro_kickstart_only(void);
 void test_repro_kickstart_only_with_vstart_zero(void);
 void test_cv49_zero_only_kickstart_works(void);
 void test_cv49_zero_with_direction_change(void);
 void test_is_bemf_enabled_compile_flags(void);
+#if !defined(OPEN_LOOP) && !defined(FORCE_OPEN_LOOP)
 void test_high_speed_logging(void);
+#endif
 void test_pwm_frequency_defaults(void);
 void test_pwm_frequency_override(void);
+#if !defined(OPEN_LOOP) && !defined(FORCE_OPEN_LOOP)
 void test_bemf_collector_gap_glitch(void);
 void test_bemf_stability_integral_clamping(void);
+#endif
 void test_read_bemf_shutdown_toggling(void);
 void test_read_bemf_internal_median(void);
+#if defined(OPEN_LOOP) || defined(FORCE_OPEN_LOOP)
+void test_open_loop_kickstart_ignores_high_bemf(void);
+void test_open_loop_adjustments_always_zero(void);
+void test_open_loop_cv_ignored_in_loop_type(void);
+#endif
 
 // Mock implementation for RP2040 reboot
 bool   reboot_called = false;
@@ -688,6 +703,7 @@ void test_motor_kickstart_bemf_disabled(void) {
   TEST_ASSERT_TRUE(foundTimeoutLog);
 }
 
+#if !defined(OPEN_LOOP) && !defined(FORCE_OPEN_LOOP)
 void test_motor_kickstart_bemf_enabled(void) {
   CvManagerMock cvManager;
   cvManager.setCv(CV_DEBUG_ENABLE, 1);
@@ -723,6 +739,7 @@ void test_motor_kickstart_bemf_enabled(void) {
   }
   TEST_ASSERT_TRUE(foundBemfLog);
 }
+#endif
 
 void test_motor_speed_curve(void) {
   CvManagerMock cvManager;
@@ -842,6 +859,7 @@ void test_serial_console_help(void) {
   TEST_ASSERT_TRUE(foundHelpHeader);
 }
 
+#if !defined(OPEN_LOOP) && !defined(FORCE_OPEN_LOOP)
 void test_high_speed_logging(void) {
   CvManagerMock   cvManager;
   ProtocolHandler protocol(0);
@@ -888,6 +906,7 @@ void test_high_speed_logging(void) {
   console.loop();
   TEST_ASSERT_FALSE(logger.isHighSpeedEnabled());
 }
+#endif
 
 void test_cv_programming_6021(void) {
   CvManagerMock   cvManager;
@@ -970,28 +989,43 @@ int main(int argc, char **argv) {
   RUN_TEST(test_serial_console_cv_readout);
   RUN_TEST(test_cv_manager_print_all);
   RUN_TEST(test_motor_kickstart_bemf_disabled);
+#if !defined(OPEN_LOOP) && !defined(FORCE_OPEN_LOOP)
   RUN_TEST(test_motor_kickstart_bemf_enabled);
+#endif
   RUN_TEST(test_motor_pwm_mapping_detailed);
   RUN_TEST(test_motor_pwm_mapping_new_defaults);
   RUN_TEST(test_debug_leds_heartbeat);
+#if !defined(OPEN_LOOP) && !defined(FORCE_OPEN_LOOP)
   RUN_TEST(test_motor_bemf_pi_control);
+#endif
   RUN_TEST(test_serial_console_logging_toggle);
   RUN_TEST(test_serial_console_help);
   RUN_TEST(test_repro_watchdog_stop_no_kickstart);
   RUN_TEST(test_repro_start_backward_kickstart_wrong_dir);
+#if !defined(OPEN_LOOP) && !defined(FORCE_OPEN_LOOP)
   RUN_TEST(test_repro_bemf_disabled_leftover_adjustment);
+#endif
   RUN_TEST(test_repro_direction_change_kickstart);
   RUN_TEST(test_repro_kickstart_only);
   RUN_TEST(test_repro_kickstart_only_with_vstart_zero);
   RUN_TEST(test_cv49_zero_only_kickstart_works);
   RUN_TEST(test_cv49_zero_with_direction_change);
   RUN_TEST(test_is_bemf_enabled_compile_flags);
+#if !defined(OPEN_LOOP) && !defined(FORCE_OPEN_LOOP)
   RUN_TEST(test_high_speed_logging);
+#endif
   RUN_TEST(test_pwm_frequency_defaults);
   RUN_TEST(test_pwm_frequency_override);
+#if !defined(OPEN_LOOP) && !defined(FORCE_OPEN_LOOP)
   RUN_TEST(test_bemf_collector_gap_glitch);
   RUN_TEST(test_bemf_stability_integral_clamping);
+#endif
   RUN_TEST(test_read_bemf_shutdown_toggling);
   RUN_TEST(test_read_bemf_internal_median);
+#if defined(OPEN_LOOP) || defined(FORCE_OPEN_LOOP)
+  RUN_TEST(test_open_loop_kickstart_ignores_high_bemf);
+  RUN_TEST(test_open_loop_adjustments_always_zero);
+  RUN_TEST(test_open_loop_cv_ignored_in_loop_type);
+#endif
   return UNITY_END();
 }

--- a/test/test_native/test_motor_analysis.cpp
+++ b/test/test_native/test_motor_analysis.cpp
@@ -87,6 +87,7 @@ void test_motor_pwm_mapping_new_defaults(void) {
   TEST_ASSERT_EQUAL(1023, get_pwm(14));
 }
 
+#if !defined(OPEN_LOOP) && !defined(FORCE_OPEN_LOOP)
 void test_motor_bemf_pi_control(void) {
   CvManagerMock cvManager;
   cvManager.setCv(CV_START_VOLTAGE, 10);  // PWM 40
@@ -132,3 +133,4 @@ void test_motor_bemf_pi_control(void) {
   motor.setSpeed(7, MM2DirectionState_Forward);
   TEST_ASSERT_EQUAL(0, analog_write_values[10]);
 }
+#endif

--- a/test/test_native/test_motor_state.cpp
+++ b/test/test_native/test_motor_state.cpp
@@ -49,6 +49,7 @@ void test_repro_start_backward_kickstart_wrong_dir(void) {
   TEST_ASSERT_EQUAL(0, analog_write_values[10]);
 }
 
+#if !defined(OPEN_LOOP) && !defined(FORCE_OPEN_LOOP)
 void test_repro_bemf_disabled_leftover_adjustment(void) {
   CvManagerMock cvManager;
   cvManager.setCv(CV_START_VOLTAGE, 10);
@@ -87,6 +88,7 @@ void test_repro_bemf_disabled_leftover_adjustment(void) {
   // FIX: adjustment should now be 0, so PWM should be 531
   TEST_ASSERT_EQUAL(531, analog_write_values[10]);
 }
+#endif
 
 void test_repro_direction_change_kickstart(void) {
   CvManagerMock cvManager;


### PR DESCRIPTION
Added a new test environment 'native_open_loop' that compiles with the -DOPEN_LOOP preprocessor flag. Also added specific test cases verifying that under open-loop compilation:
1) Kickstart is never prematurely ended by BEMF feedback.
2) No PI controller adjustments are ever applied.
3) BEMF-enabling CV flags are ignored.
Finally, integrated this open-loop test run into the GitHub Actions CI workflow to ensure continued flawless compatibility.

Fixes #285

---
*PR created automatically by Jules for task [14256059422799775544](https://jules.google.com/task/14256059422799775544) started by @chatelao*