### PR TITLE
Verify CV 2 Start Voltage is active in open-loop mode

### DIFF
--- a/test/test_native/test_cv49_verification.cpp
+++ b/test/test_native/test_cv49_verification.cpp
@@ -118,6 +118,55 @@ void test_is_bemf_enabled_compile_flags(void) {
 #endif
 }
 
+void test_open_loop_start_voltage_active(void) {
+    CvManagerMock cvManager;
+    cvManager.setCv(CV_MEDIUM_SPEED, 0);
+    cvManager.setCv(CV_MAXIMUM_SPEED, 0);
+    cvManager.setCv(CV_BEMF_CONFIG, 0); // Open-loop mode at runtime (or compile-time anyway)
+    cvManager.setCv(CV_MOTOR_TYPE, 0);
+
+    // Test with CV_START_VOLTAGE = 20
+    cvManager.setCv(CV_START_VOLTAGE, 20);
+    {
+        MotorControl motor(cvManager, 10, 11, 2, 3, 12);
+        motor.setup();
+
+        // Speed step 1 -> trigger kickstart first
+        motor.setSpeed(1, MM2DirectionState_Forward);
+        TEST_ASSERT_TRUE(motor.isKickstarting());
+
+        // Wait past kickstart timeout
+        advance_millis(150);
+        motor.setSpeed(1, MM2DirectionState_Forward);
+        TEST_ASSERT_FALSE(motor.isKickstarting());
+
+        // Check PWM is vStart (which maps 20 -> 80)
+        TEST_ASSERT_EQUAL(80, analog_write_values[10]);
+    }
+
+    // Reset mocks for next sub-test
+    reset_arduino_mock();
+
+    // Test with CV_START_VOLTAGE = 50
+    cvManager.setCv(CV_START_VOLTAGE, 50);
+    {
+        MotorControl motor(cvManager, 10, 11, 2, 3, 12);
+        motor.setup();
+
+        // Speed step 1 -> trigger kickstart first
+        motor.setSpeed(1, MM2DirectionState_Forward);
+        TEST_ASSERT_TRUE(motor.isKickstarting());
+
+        // Wait past kickstart timeout
+        advance_millis(150);
+        motor.setSpeed(1, MM2DirectionState_Forward);
+        TEST_ASSERT_FALSE(motor.isKickstarting());
+
+        // Check PWM is vStart (which maps 50 -> 200)
+        TEST_ASSERT_EQUAL(200, analog_write_values[10]);
+    }
+}
+
 #if defined(OPEN_LOOP) || defined(FORCE_OPEN_LOOP)
 void test_open_loop_kickstart_ignores_high_bemf(void) {
     CvManagerMock cvManager;

--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -45,6 +45,7 @@ void test_repro_kickstart_only_with_vstart_zero(void);
 void test_cv49_zero_only_kickstart_works(void);
 void test_cv49_zero_with_direction_change(void);
 void test_is_bemf_enabled_compile_flags(void);
+void test_open_loop_start_voltage_active(void);
 #if !defined(OPEN_LOOP) && !defined(FORCE_OPEN_LOOP)
 void test_high_speed_logging(void);
 #endif
@@ -1011,6 +1012,7 @@ int main(int argc, char **argv) {
   RUN_TEST(test_cv49_zero_only_kickstart_works);
   RUN_TEST(test_cv49_zero_with_direction_change);
   RUN_TEST(test_is_bemf_enabled_compile_flags);
+  RUN_TEST(test_open_loop_start_voltage_active);
 #if !defined(OPEN_LOOP) && !defined(FORCE_OPEN_LOOP)
   RUN_TEST(test_high_speed_logging);
 #endif


### PR DESCRIPTION
Added the `test_open_loop_start_voltage_active` unit test to verify that the Start Voltage Configuration Variable (CV 2) is active and correctly scales the applied motor PWM duty cycles in open-loop mode.

Fixes #289

---
*PR created automatically by Jules for task [12506824964261855541](https://jules.google.com/task/12506824964261855541) started by @chatelao*